### PR TITLE
[libconnman-qt] Optimize qt signal connections. JB#56225 OMP#JOLLA-552

### DIFF
--- a/libconnman-qt/networkmanager.h
+++ b/libconnman-qt/networkmanager.h
@@ -177,6 +177,7 @@ private:
     QVector<NetworkService*> selectServices(const QStringList &list, ServiceSelector selector) const;
     QStringList selectServiceList(const QStringList &list, const QString &tech) const;
     QStringList selectServiceList(const QStringList &list, ServiceSelector selector) const;
+    void updateDefaultRoute();
 
 private:
     class Private;
@@ -224,7 +225,6 @@ private Q_SLOTS:
     void technologyAdded(const QDBusObjectPath &technology, const QVariantMap &properties);
     void technologyRemoved(const QDBusObjectPath &technology);
     void getPropertiesFinished(QDBusPendingCallWatcher *watcher);
-    void updateDefaultRoute();
     void getTechnologiesFinished(QDBusPendingCallWatcher *watcher);
     void getServicesFinished(QDBusPendingCallWatcher *watcher);
 


### PR DESCRIPTION
Use newer and better performing method pointer API,
avoid multiple connections to the same signal.

TechnologyModel adjusted to follow service destruction only when
changes are inhibited. Otherwise we should anyway get the updated
list.

The service list updates can come relatively often and with lot of
services so these might even have some effect.

@monich @LaakkonenJussi @ikamaletdinov

Disclaimer: don't have too many wlans available here for testing. 