### PR TITLE
Always return both saved and available ethernet services.

### DIFF
--- a/libconnman-qt/networkmanager.cpp
+++ b/libconnman-qt/networkmanager.cpp
@@ -1101,9 +1101,7 @@ QVector<NetworkService*> NetworkManager::getSavedServices(const QString &tech) c
             return selectServices(m_priv->m_cellularServicesOrder, Private::selectSaved);
         }
     } else if (tech == Private::EthernetType) {
-        if (m_priv->m_ethernetServicesOrder.count() < m_savedServicesOrder.count()) {
-            return selectServices(m_priv->m_ethernetServicesOrder, Private::selectSavedOrAvailable);
-        }
+        return selectServices(m_priv->m_ethernetServicesOrder, Private::selectSavedOrAvailable);
     }
     return selectServices(m_savedServicesOrder, tech);
 }
@@ -1120,9 +1118,7 @@ QVector<NetworkService*> NetworkManager::getAvailableServices(const QString &tec
             return selectServices(m_priv->m_cellularServicesOrder, Private::selectAvailable);
         }
     } else if (tech == Private::EthernetType) {
-        if (m_priv->m_cellularServicesOrder.count() < m_priv->m_availableServicesOrder.count()) {
-            return selectServices(m_priv->m_ethernetServicesOrder, Private::selectAvailable);
-        }
+        return selectServices(m_priv->m_ethernetServicesOrder, Private::selectAvailable);
     }
     return selectServices(m_priv->m_availableServicesOrder, tech);
 }


### PR DESCRIPTION
Do not compare the list counts with ethernet services. This may result
in a situation where the available services are not shown when the
ethernet services are to be requested on a newly flashed device or when
there hasn't been many other services saved or in use. The ethernet
services work in a bit different way as they on the first run are not
saved at all but are created by ConnMan when LOWER_UP is being detected
and thus, they are shown as available. This makes the available and
saved ethernet services to be shown always whenever there is at least
one of either.