### PR TITLE
[libconnman-qt] Fixup warning on Qt >= 5.10

### DIFF
--- a/libconnman-qt/counter.cpp
+++ b/libconnman-qt/counter.cpp
@@ -31,10 +31,10 @@ Counter::Counter(QObject *parent) :
     shouldBeRunning(false),
     registered(false)
 {
-    QTime time = QTime::currentTime();
     #if (QT_VERSION >= QT_VERSION_CHECK(5,10,0))
         quint32 randomValue = QRandomGenerator::global()->generate();
     #else
+        QTime time = QTime::currentTime();
         qsrand((uint)time.msec());
         int randomValue = qrand();
     #endif


### PR DESCRIPTION
```
counter.cpp: In constructor ‘Counter::Counter(QObject*)’:
counter.cpp:34:11: warning: variable ‘time’ set but not used [-Wunused-but-set-variable]
   34 |     QTime time = QTime::currentTime();
      |           ^~~~

```