### PR TITLE
[libconnman-qt] Support VPN association state. JB#59447

### DIFF
--- a/libconnman-qt/marshalutils.cpp
+++ b/libconnman-qt/marshalutils.cpp
@@ -45,6 +45,7 @@ QVariant convertState (const QString &key, const QVariant &value, bool toDBus)
     QList<QPair<QVariant, QVariant> > states;
     states.push_back(qMakePair(QVariant::fromValue(QStringLiteral("idle")), QVariant::fromValue(static_cast<int>(VpnConnection::Idle))));
     states.push_back(qMakePair(QVariant::fromValue(QStringLiteral("failure")), QVariant::fromValue(static_cast<int>(VpnConnection::Failure))));
+    states.push_back(qMakePair(QVariant::fromValue(QStringLiteral("association")), QVariant::fromValue(static_cast<int>(VpnConnection::Association))));
     states.push_back(qMakePair(QVariant::fromValue(QStringLiteral("configuration")), QVariant::fromValue(static_cast<int>(VpnConnection::Configuration))));
     states.push_back(qMakePair(QVariant::fromValue(QStringLiteral("ready")), QVariant::fromValue(static_cast<int>(VpnConnection::Ready))));
     states.push_back(qMakePair(QVariant::fromValue(QStringLiteral("disconnect")), QVariant::fromValue(static_cast<int>(VpnConnection::Disconnect))));

--- a/libconnman-qt/vpnconnection.h
+++ b/libconnman-qt/vpnconnection.h
@@ -81,6 +81,7 @@ public:
     enum ConnectionState {
         Idle,
         Failure,
+        Association,
         Configuration,
         Ready,
         Disconnect

--- a/libconnman-qt/vpnmanager.cpp
+++ b/libconnman-qt/vpnmanager.cpp
@@ -208,7 +208,9 @@ void VpnManager::deleteConnection(const QString &path)
     Q_D(VpnManager);
 
     if (VpnConnection *conn = connection(path)) {
-        if (conn->state() == VpnConnection::Ready || conn->state() == VpnConnection::Configuration) {
+        if (conn->state() == VpnConnection::Ready ||
+                                conn->state() == VpnConnection::Configuration ||
+                                conn->state() == VpnConnection::Association) {
             conn->setAutoConnect(false);
 
             connect(conn, &VpnConnection::stateChanged, this, [this, path, conn](){
@@ -244,7 +246,8 @@ void VpnManager::activateConnection(const QString &path)
     for (VpnConnection *conn : d->m_items) {
         QString otherPath = conn->path();
         if (otherPath != path && (conn->state() == VpnConnection::Ready ||
-                                  conn->state() == VpnConnection::Configuration)) {
+                                conn->state() == VpnConnection::Configuration ||
+                                conn->state() == VpnConnection::Association)) {
             deactivateConnection(otherPath);
             qDebug() << "Adding pending vpn disconnect" << otherPath << conn->state() << "when connecting to vpn";
         }

--- a/plugin/plugins.qmltypes
+++ b/plugin/plugins.qmltypes
@@ -912,9 +912,10 @@ Module {
             values: {
                 "Idle": 0,
                 "Failure": 1,
-                "Configuration": 2,
-                "Ready": 3,
-                "Disconnect": 4
+                "Association": 2,
+                "Configuration": 3,
+                "Ready": 4,
+                "Disconnect": 5
             }
         }
         Property { name: "path"; type: "string"; isReadonly: true }

--- a/rpm/connman-qt5.spec
+++ b/rpm/connman-qt5.spec
@@ -1,11 +1,11 @@
 Name:       connman-qt5
 Summary:    Qt bindings for connman
-Version:    1.2.35
+Version:    1.2.48
 Release:    1
 License:    ASL 2.0
 URL:        https://git.sailfishos.org/mer-core/libconnman-qt
 Source0:    %{name}-%{version}.tar.bz2
-Requires:   connman >= 1.32+git138
+Requires:   connman >= 1.32+git191
 Requires:   libdbusaccess >= 1.0.4
 Requires(post): /sbin/ldconfig
 Requires(postun): /sbin/ldconfig


### PR DESCRIPTION
Add support for the association state for VPNs. This is the state when VPN is querying VPN agent (user) for credentials. Behavior is similar as with other services as association is the generic state in connmand that is the state prior to configuration.