### PR TITLE
[libconnman-qt] Fix NetworkTechnology objects removal

### DIFF
--- a/libconnman-qt/networkmanager.cpp
+++ b/libconnman-qt/networkmanager.cpp
@@ -900,7 +900,7 @@ void NetworkManager::technologyRemoved(const QDBusObjectPath &technology)
     // if we weren't storing by type() this loop would be unecessary
     // but since this function will be triggered rarely that's fine
     for (NetworkTechnology *net : m_technologiesCache) {
-        if (net->objPath() == technology.path()) {
+        if (net->path() == technology.path()) {
             m_technologiesCache.remove(net->type());
             net->deleteLater();
             break;


### PR DESCRIPTION
Before NetworkManager::technologyRemoved is called there is NetworkTechnology::technologyRemoved which destroys interface (delete m_technology) so objPath() returns QString(). This leads to memory leak and flood of dbus GetProperties messages increasing on every technology add/remove.