### PR TITLE
[libconnman-qt] Clarify getTechnology() API dangers. JB#59734

### DIFF
--- a/libconnman-qt/networkmanager.h
+++ b/libconnman-qt/networkmanager.h
@@ -72,6 +72,10 @@ public:
 
     bool isAvailable() const;
 
+    // Note: the resulting pointer on getTechnology() and getTechnologies() can get invalid after the next
+    // technologiesUpdated signal, so need to be sure to fetch values again and stop using pointers that
+    // are no longer available.
+    // Note: using getTechnology() from QML is discouraged and the Q_INVOKABLE might get removed
     Q_INVOKABLE NetworkTechnology* getTechnology(const QString &type) const;
     QVector<NetworkTechnology *> getTechnologies() const;
     QVector<NetworkService*> getServices(const QString &tech = QString()) const;

--- a/libconnman-qt/networktechnology.cpp
+++ b/libconnman-qt/networktechnology.cpp
@@ -102,7 +102,6 @@ void NetworkTechnology::initialize()
             QDBusPendingReply<ConnmanObjectList> reply = *watcher;
             watcher->deleteLater();
 
-
             if (reply.isError()) {
                 DBG_("Failed to connman techonologies:" << reply.isError() << reply.error().type());
             } else {


### PR DESCRIPTION
More or less unused API for which the implementation didn't specify ownership to c++. Then with both qml and c++ deleting content without telling others it's been a problem just waiting to arise.

Instead providing now a simpler hasTechnology(string).

The NetworkTechnology can be instantiated also directly, which is the common usage.

@mlehtima @LaakkonenJussi 