### PR TITLE
vpnmodel: correctly include local headers

### DIFF
--- a/libconnman-qt/vpnmodel.cpp
+++ b/libconnman-qt/vpnmodel.cpp
@@ -31,8 +31,8 @@
  */
 
 #include <QtDBus>
-#include <vpnmanager.h>
-#include <vpnconnection.h>
+#include "vpnmanager.h"
+#include "vpnconnection.h"
 
 #include "vpnmodel.h"
 #include "vpnmodel_p.h"


### PR DESCRIPTION
local included headers were given brackets instead of quotes so they were searched first at a system level.

This was breaking my static build of such library