### PR TITLE
Follow DefaultRoute signal, use ordered list in checking default route.

### DIFF
--- a/libconnman-qt/networkmanager.h
+++ b/libconnman-qt/networkmanager.h
@@ -179,6 +179,7 @@ private:
     void disconnectFromConnman();
     QVector<NetworkService*> selectServices(const QStringList &list, const QString &tech) const;
     QVector<NetworkService*> selectServices(const QStringList &list, ServiceSelector selector) const;
+    NetworkService* selectDefaultRoute(const QString &path) const;
     QStringList selectServiceList(const QStringList &list, const QString &tech) const;
     QStringList selectServiceList(const QStringList &list, ServiceSelector selector) const;
     void updateDefaultRoute();
@@ -212,6 +213,7 @@ private:
     static const QString State;
     static const QString OfflineMode;
     static const QString SessionMode;
+    static const QString DefaultService;
 
     bool m_available;
     bool m_servicesEnabled;

--- a/libconnman-qt/networkmanager.h
+++ b/libconnman-qt/networkmanager.h
@@ -179,7 +179,7 @@ private:
     void disconnectFromConnman();
     QVector<NetworkService*> selectServices(const QStringList &list, const QString &tech) const;
     QVector<NetworkService*> selectServices(const QStringList &list, ServiceSelector selector) const;
-    NetworkService* selectDefaultRoute(const QString &path) const;
+    NetworkService* selectDefaultRoute(const QString &path);
     QStringList selectServiceList(const QStringList &list, const QString &tech) const;
     QStringList selectServiceList(const QStringList &list, ServiceSelector selector) const;
     void updateDefaultRoute();
@@ -207,6 +207,9 @@ private:
 
     /* Invalid default route service for use when there is no default route */
     NetworkService *m_invalidDefaultRoute;
+
+    /* Since VPNs are not known this holds info necessary for dropping out of VPN */
+    bool m_defaultRouteIsVPN;
 
     Private *m_priv;
 

--- a/rpm/connman-qt5.spec
+++ b/rpm/connman-qt5.spec
@@ -5,7 +5,7 @@ Release:    1
 License:    ASL 2.0
 URL:        https://github.com/sailfishos/libconnman-qt/
 Source0:    %{name}-%{version}.tar.bz2
-Requires:   connman >= 1.32+git191
+Requires:   connman >= 1.32+git208
 Requires:   libdbusaccess >= 1.0.4
 Requires(post): /sbin/ldconfig
 Requires(postun): /sbin/ldconfig


### PR DESCRIPTION
Monitor the DefaultRoute PropertyChanged signal and use ordered list for checking default route in order to improve default route management. This information contains also VPNs that are not supported by networkmanager  and in such case the next connected from the ordered list is selected  as "default" which is effectively the transport. This is to keep the upper layers informed that the network is still connected.