### PR TITLE
Cleanup selectDefaultRoute debugging

### DIFF
--- a/libconnman-qt/networkmanager.cpp
+++ b/libconnman-qt/networkmanager.cpp
@@ -885,15 +885,12 @@ NetworkService* NetworkManager::selectDefaultRoute(const QString &path)
                     qDebug() << "VPN is set as default route";
                 }
 
-                qDebug() << "VPN service, continue";
                 continue;
             }
 
             qDebug() << "Selected service" << newDefaultRoute->name() << "path" << servicePath;
             return newDefaultRoute;
         }
-
-        qDebug() << "Service not connected, continue";
     }
 
     qDebug() << "No transport service found";


### PR DESCRIPTION
These debug messages within the loop provide no relevant information. Instead, they obfuscate the logs more.