### PR TITLE
Add checks for not repeating actions, clean debug

### DIFF
--- a/libconnman-qt/networkmanager.h
+++ b/libconnman-qt/networkmanager.h
@@ -197,6 +197,7 @@ private:
     /* Not just for cache, but actual containers of Network* type objects */
     QHash<QString, NetworkTechnology *> m_technologiesCache;
     QHash<QString, NetworkService *> m_servicesCache;
+    bool m_servicesCacheHasUpdates;
 
     /* Define the order of services returned in service lists */
     QStringList m_servicesOrder;


### PR DESCRIPTION
Do the default route update only when there are changes in the service cache. This prevents doing unnecessary list traversals when there are no updates or when the default route is kept as the same.

Also drop out from the services cache traversal when first not connected service is encountered since the service states are used for the ordered list originating from ConnMan.

And cleanup some old debug to make output more clear.