### PR TITLE
Shared instance api. JB#61563

### DIFF
--- a/libconnman-qt/connmannetworkproxyfactory.h
+++ b/libconnman-qt/connmannetworkproxyfactory.h
@@ -14,6 +14,7 @@
 #include <QtCore/QVariantMap>
 #include <QtNetwork/QNetworkProxyFactory>
 
+#include "networkmanager.h"
 class NetworkService;
 
 class ConnmanNetworkProxyFactory : public QObject, public QNetworkProxyFactory
@@ -34,6 +35,7 @@ private:
     QPointer<NetworkService> m_defaultRoute;
     QList<QNetworkProxy> m_cachedProxies_all;
     QList<QNetworkProxy> m_cachedProxies_udpSocketOrTcpServerCapable;
+    QSharedPointer<NetworkManager> m_networkManager;
 };
 
 #endif //CONNMANNETWORKPROXYFACTORY_H

--- a/libconnman-qt/counter.cpp
+++ b/libconnman-qt/counter.cpp
@@ -18,7 +18,7 @@
 
 Counter::Counter(QObject *parent) :
     QObject(parent),
-    m_manager(NetworkManagerFactory::createInstance()),
+    m_manager(NetworkManager::sharedInstance()),
     bytesInHome(0),
     bytesOutHome(0),
     secondsOnlineHome(0),
@@ -31,13 +31,13 @@ Counter::Counter(QObject *parent) :
     shouldBeRunning(false),
     registered(false)
 {
-    #if (QT_VERSION >= QT_VERSION_CHECK(5,10,0))
-        quint32 randomValue = QRandomGenerator::global()->generate();
-    #else
-        QTime time = QTime::currentTime();
-        qsrand((uint)time.msec());
-        int randomValue = qrand();
-    #endif
+#if (QT_VERSION >= QT_VERSION_CHECK(5,10,0))
+    quint32 randomValue = QRandomGenerator::global()->generate();
+#else
+    QTime time = QTime::currentTime();
+    qsrand((uint)time.msec());
+    int randomValue = qrand();
+#endif
     //this needs to be unique so we can use more than one at a time with different processes
     counterPath = "/ConnectivityCounter" + QString::number(randomValue);
 
@@ -45,7 +45,8 @@ Counter::Counter(QObject *parent) :
     if (!QDBusConnection::systemBus().registerObject(counterPath, this))
         qWarning("Could not register DBus object on %s", qPrintable(counterPath));
 
-    connect(m_manager, SIGNAL(availabilityChanged(bool)), this, SLOT(updateCounterAgent()));
+    connect(m_manager.data(), &NetworkManager::availabilityChanged,
+            this, &Counter::updateCounterAgent);
 }
 
 Counter::~Counter()

--- a/libconnman-qt/counter.h
+++ b/libconnman-qt/counter.h
@@ -15,7 +15,7 @@
 #include <QtDBus/QDBusAbstractAdaptor>
 #include <QtDBus/QDBusObjectPath>
 
-class NetworkManager;
+#include "networkmanager.h"
 
 /*
  * Proxy class for interface net.connman.Counter
@@ -70,7 +70,7 @@ private Q_SLOTS:
     void updateCounterAgent();
 
 private:
-    NetworkManager* m_manager;
+    QSharedPointer<NetworkManager> m_manager;
 
     friend class CounterAdaptor;
 

--- a/libconnman-qt/libconnman-qt.pro
+++ b/libconnman-qt/libconnman-qt.pro
@@ -42,6 +42,7 @@ custom_dbus_interface.files = \
     connman_service.xml \
     connman_vpn_manager.xml \
     connman_vpn_connection.xml
+
 custom_dbus_interface.header_flags = -i qdbusxml2cpp_dbus_types.h
 
 DBUS_INTERFACES = \
@@ -72,9 +73,7 @@ HEADERS += \
     $$PUBLIC_HEADERS \
     libconnman_p.h \
     marshalutils.h \
-    qdbusxml2cpp_dbus_types.h \
-    connman_vpn_manager_interface.h \
-    connman_vpn_connection_interface.h
+    qdbusxml2cpp_dbus_types.h
 
 SOURCES += \
     marshalutils.cpp \

--- a/libconnman-qt/networkmanager.cpp
+++ b/libconnman-qt/networkmanager.cpp
@@ -19,7 +19,7 @@
 
 static NetworkManager* staticInstance = NULL;
 
-NetworkManager* NetworkManagerFactory::createInstance()
+static NetworkManager* internalCreateInstance()
 {
     qWarning() << "NetworkManagerFactory::createInstance/instance() is deprecated. Use NetworkManager::sharedInstance() instead.";
     if (!staticInstance)
@@ -28,9 +28,14 @@ NetworkManager* NetworkManagerFactory::createInstance()
     return staticInstance;
 }
 
+NetworkManager* NetworkManagerFactory::createInstance()
+{
+    return internalCreateInstance();
+}
+
 NetworkManager* NetworkManagerFactory::instance()
 {
-    return createInstance();
+    return internalCreateInstance();
 }
 
 // ==========================================================================
@@ -450,7 +455,7 @@ NetworkManager::~NetworkManager()
 NetworkManager* NetworkManager::instance()
 {
     qWarning() << "NetworkManager::instance() is deprecated. Use sharedInstance() instead.";
-    return NetworkManagerFactory::createInstance();
+    return internalCreateInstance();
 }
 
 QSharedPointer<NetworkManager> NetworkManager::sharedInstance()

--- a/libconnman-qt/networkmanager.cpp
+++ b/libconnman-qt/networkmanager.cpp
@@ -11,6 +11,7 @@
 
 #include "libconnman_p.h"
 #include <QRegularExpression>
+#include <QWeakPointer>
 
 // ==========================================================================
 // NetworkManagerFactory
@@ -20,6 +21,7 @@ static NetworkManager* staticInstance = NULL;
 
 NetworkManager* NetworkManagerFactory::createInstance()
 {
+    qWarning() << "NetworkManagerFactory::createInstance/instance() is deprecated. Use NetworkManager::sharedInstance() instead.";
     if (!staticInstance)
         staticInstance = new NetworkManager;
 
@@ -447,7 +449,22 @@ NetworkManager::~NetworkManager()
 
 NetworkManager* NetworkManager::instance()
 {
+    qWarning() << "NetworkManager::instance() is deprecated. Use sharedInstance() instead.";
     return NetworkManagerFactory::createInstance();
+}
+
+QSharedPointer<NetworkManager> NetworkManager::sharedInstance()
+{
+    static QWeakPointer<NetworkManager> sharedManager;
+
+    QSharedPointer<NetworkManager> manager = sharedManager.toStrongRef();
+
+    if (!manager) {
+        manager = QSharedPointer<NetworkManager>::create();
+        sharedManager = manager;
+    }
+
+    return manager;
 }
 
 void NetworkManager::onConnmanRegistered()

--- a/libconnman-qt/networkmanager.cpp
+++ b/libconnman-qt/networkmanager.cpp
@@ -430,9 +430,7 @@ NetworkManager::NetworkManager(QObject* parent)
     m_invalidDefaultRoute(new NetworkService("/", QVariantMap(), this)),
     m_defaultRouteIsVPN(false),
     m_priv(new Private(this)),
-    m_available(false),
-    m_servicesEnabled(true),
-    m_technologiesEnabled(true)
+    m_available(false)
 {
     registerCommonDataTypes();
     QDBusServiceWatcher* watcher = new QDBusServiceWatcher(CONNMAN_SERVICE, CONNMAN_BUS,
@@ -1001,10 +999,8 @@ void NetworkManager::getPropertiesFinished(QDBusPendingCallWatcher *watcher)
     for (QVariantMap::ConstIterator i = props.constBegin(); i != props.constEnd(); ++i)
         propertyChanged(i.key(), i.value());
 
-    if (m_technologiesEnabled)
-        setupTechnologies();
-    if (m_servicesEnabled)
-        setupServices();
+    setupTechnologies();
+    setupServices();
 }
 
 void NetworkManager::getTechnologiesFinished(QDBusPendingCallWatcher *watcher)
@@ -1432,70 +1428,27 @@ uint NetworkManager::inputRequestTimeout() const
 
 bool NetworkManager::servicesEnabled() const
 {
-    return m_servicesEnabled;
+    return true;
 }
 
-void NetworkManager::setServicesEnabled(bool enabled)
+void NetworkManager::setServicesEnabled(bool)
 {
-    if (m_servicesEnabled == enabled)
-        return;
-
-    if (this == staticInstance) {
-        qWarning() << "Refusing to modify the shared instance";
-        return;
-    }
-
-    bool wasValid = isValid();
-
-    m_servicesEnabled = enabled;
-
-    if (m_servicesEnabled)
-        setupServices();
-    else
-        disconnectServices();
-
-    Q_EMIT servicesEnabledChanged();
-
-    if (wasValid != isValid()) {
-        Q_EMIT validChanged();
-    }
+    qWarning() << "NetworkManager::setServicesEnabled() is deprecated, this call will be ignored";
 }
 
 bool NetworkManager::technologiesEnabled() const
 {
-    return m_technologiesEnabled;
+    return true;
 }
 
-void NetworkManager::setTechnologiesEnabled(bool enabled)
+void NetworkManager::setTechnologiesEnabled(bool)
 {
-    if (m_technologiesEnabled == enabled)
-        return;
-
-    if (this == staticInstance) {
-        qWarning() << "Refusing to modify the shared instance";
-        return;
-    }
-
-    bool wasValid = isValid();
-
-    m_technologiesEnabled = enabled;
-
-    if (m_technologiesEnabled)
-        setupTechnologies();
-    else
-        disconnectTechnologies();
-
-    Q_EMIT technologiesEnabledChanged();
-
-    if (wasValid != isValid()) {
-        Q_EMIT validChanged();
-    }
+    qWarning() << "NetworkManager::setTechnologiesEnabled() is deprecated, this call will be ignored";
 }
 
 bool NetworkManager::isValid() const
 {
-    return (!m_servicesEnabled || m_priv->m_servicesAvailable)
-            && (!m_technologiesEnabled || m_priv->m_technologiesAvailable);
+    return m_priv->m_servicesAvailable && m_priv->m_technologiesAvailable;
 }
 
 bool NetworkManager::connected() const

--- a/libconnman-qt/networkmanager.cpp
+++ b/libconnman-qt/networkmanager.cpp
@@ -420,7 +420,6 @@ Q_SIGNALS:
 
 const QString NetworkManager::State("State");
 const QString NetworkManager::OfflineMode("OfflineMode");
-const QString NetworkManager::SessionMode("SessionMode");
 const QString NetworkManager::DefaultService("DefaultService");
 
 const QString NetworkManager::WifiTechnologyPath("/net/connman/technology/wifi");
@@ -1385,11 +1384,9 @@ QString NetworkManager::createServiceSync(
     }
 }
 
-void NetworkManager::setSessionMode(bool sessionMode)
+void NetworkManager::setSessionMode(bool)
 {
-    if (m_proxy) {
-        m_proxy->SetProperty(SessionMode, sessionMode);
-    }
+    qWarning() << "NetworkManager::setSessionMode() is deprecated, this call will be ignored";
 }
 
 void NetworkManager::propertyChanged(const QString &name, const QVariant &value)
@@ -1428,8 +1425,6 @@ void NetworkManager::propertyChanged(const QString &name, const QVariant &value)
 
         if (name == OfflineMode) {
             Q_EMIT offlineModeChanged(value.toBool());
-        } else if (name == SessionMode) {
-            Q_EMIT sessionModeChanged(value.toBool());
         } else if (name == Private::InputRequestTimeout) {
             Q_EMIT inputRequestTimeoutChanged();
         }
@@ -1438,7 +1433,8 @@ void NetworkManager::propertyChanged(const QString &name, const QVariant &value)
 
 bool NetworkManager::sessionMode() const
 {
-    return m_propertiesCache.value(SessionMode).toBool();
+    qWarning() << "NetworkManager::sessionMode() is deprecated, this will return hard-coded false";
+    return false;
 }
 
 uint NetworkManager::inputRequestTimeout() const

--- a/libconnman-qt/networkmanager.h
+++ b/libconnman-qt/networkmanager.h
@@ -38,7 +38,7 @@ class NetworkManager : public QObject
     Q_PROPERTY(NetworkService* defaultRoute READ defaultRoute NOTIFY defaultRouteChanged)
     Q_PROPERTY(NetworkService* connectedWifi READ connectedWifi NOTIFY connectedWifiChanged)
     Q_PROPERTY(NetworkService* connectedEthernet READ connectedEthernet NOTIFY connectedEthernetChanged)
-    Q_PROPERTY(bool connectingWifi READ connectingWifi NOTIFY connectingChanged)
+    Q_PROPERTY(bool connectingWifi READ connectingWifi NOTIFY connectingWifiChanged)
 
     Q_PROPERTY(bool sessionMode READ sessionMode WRITE setSessionMode NOTIFY sessionModeChanged)
     Q_PROPERTY(uint inputRequestTimeout READ inputRequestTimeout NOTIFY inputRequestTimeoutChanged)

--- a/libconnman-qt/networkmanager.h
+++ b/libconnman-qt/networkmanager.h
@@ -77,7 +77,6 @@ public:
     // Note: the resulting pointer on getTechnology() and getTechnologies() can get invalid after the next
     // technologiesUpdated signal, so need to be sure to fetch values again and stop using pointers that
     // are no longer available.
-    // Note: using getTechnology() from QML is discouraged and the Q_INVOKABLE might get removed
     Q_INVOKABLE NetworkTechnology* getTechnology(const QString &type) const;
     QVector<NetworkTechnology *> getTechnologies() const;
     QVector<NetworkService*> getServices(const QString &tech = QString()) const;

--- a/libconnman-qt/networkmanager.h
+++ b/libconnman-qt/networkmanager.h
@@ -32,15 +32,13 @@ public:
 class NetworkManager : public QObject
 {
     Q_OBJECT
-
     Q_PROPERTY(bool available READ isAvailable NOTIFY availabilityChanged)
     Q_PROPERTY(QString state READ state NOTIFY stateChanged)
     Q_PROPERTY(bool offlineMode READ offlineMode WRITE setOfflineMode NOTIFY offlineModeChanged)
     Q_PROPERTY(NetworkService* defaultRoute READ defaultRoute NOTIFY defaultRouteChanged)
     Q_PROPERTY(NetworkService* connectedWifi READ connectedWifi NOTIFY connectedWifiChanged)
-    Q_PROPERTY(bool connectingWifi READ connectingWifi NOTIFY connectingChanged)
-
     Q_PROPERTY(NetworkService* connectedEthernet READ connectedEthernet NOTIFY connectedEthernetChanged)
+    Q_PROPERTY(bool connectingWifi READ connectingWifi NOTIFY connectingChanged)
 
     Q_PROPERTY(bool sessionMode READ sessionMode WRITE setSessionMode NOTIFY sessionModeChanged)
     Q_PROPERTY(uint inputRequestTimeout READ inputRequestTimeout NOTIFY inputRequestTimeoutChanged)

--- a/libconnman-qt/networkmanager.h
+++ b/libconnman-qt/networkmanager.h
@@ -218,8 +218,6 @@ private:
     static const QString DefaultService;
 
     bool m_available;
-    bool m_servicesEnabled;
-    bool m_technologiesEnabled;
 
 private Q_SLOTS:
     void onConnmanRegistered();

--- a/libconnman-qt/networkmanager.h
+++ b/libconnman-qt/networkmanager.h
@@ -26,7 +26,8 @@ class NetworkManagerFactory : public QObject
     Q_PROPERTY(NetworkManager* instance READ instance CONSTANT)
 
 public:
-    static NetworkManager* createInstance();
+    Q_DECL_DEPRECATED_X("Use NetworkManager::sharedInstance()") static NetworkManager* createInstance();
+    // deprecated
     NetworkManager* instance();
 };
 
@@ -64,8 +65,7 @@ public:
     static const QString GpsTechnologyPath;
     static const QString EthernetTechnologyPath;
 
-    // deprecated
-    static NetworkManager* instance();
+    Q_DECL_DEPRECATED_X("Use NetworkManager::sharedInstance()") static NetworkManager* instance();
 
     static QSharedPointer<NetworkManager> sharedInstance();
 
@@ -102,10 +102,14 @@ public:
     bool sessionMode() const;
     uint inputRequestTimeout() const;
 
+    // deprecated
     bool servicesEnabled() const;
+    // deprecated
     void setServicesEnabled(bool enabled);
 
+    // deprecated
     bool technologiesEnabled() const;
+    // deprecated
     void setTechnologiesEnabled(bool enabled);
 
     bool isValid() const;

--- a/libconnman-qt/networkmanager.h
+++ b/libconnman-qt/networkmanager.h
@@ -15,13 +15,14 @@
 #include "networktechnology.h"
 #include "networkservice.h"
 #include <QtDBus>
+#include <QSharedPointer>
 
 class NetworkManager;
 
+// This class is deprecated
 class NetworkManagerFactory : public QObject
 {
     Q_OBJECT
-
     Q_PROPERTY(NetworkManager* instance READ instance CONSTANT)
 
 public:
@@ -63,7 +64,10 @@ public:
     static const QString GpsTechnologyPath;
     static const QString EthernetTechnologyPath;
 
+    // deprecated
     static NetworkManager* instance();
+
+    static QSharedPointer<NetworkManager> sharedInstance();
 
     NetworkManager(QObject *parent = 0);
     virtual ~NetworkManager();

--- a/libconnman-qt/networkmanager.h
+++ b/libconnman-qt/networkmanager.h
@@ -99,6 +99,7 @@ public:
 
     NetworkService *connectedEthernet() const;
 
+    // deprecated
     bool sessionMode() const;
     uint inputRequestTimeout() const;
 
@@ -143,6 +144,7 @@ public Q_SLOTS:
             const QString &tech = QString(),
             const QString &service = QString(),
             const QString &device = QString());
+    // deprecated
     void setSessionMode(bool sessionMode);
 
 Q_SIGNALS:
@@ -221,7 +223,6 @@ private:
 
     static const QString State;
     static const QString OfflineMode;
-    static const QString SessionMode;
     static const QString DefaultService;
 
     bool m_available;

--- a/libconnman-qt/networktechnology.cpp
+++ b/libconnman-qt/networktechnology.cpp
@@ -211,8 +211,9 @@ void NetworkTechnology::technologyRemoved(const QDBusObjectPath &technology)
 
 void NetworkTechnology::pendingSetProperty(const QString &key, const QVariant &value)
 {
-    connect(new QDBusPendingCallWatcher(m_technology->SetProperty(key, QDBusVariant(value)), m_technology),
-        &QDBusPendingCallWatcher::finished,
+    QDBusPendingCallWatcher *pendingCall
+            = new QDBusPendingCallWatcher(m_technology->SetProperty(key, QDBusVariant(value)), m_technology);
+    connect(pendingCall, &QDBusPendingCallWatcher::finished,
             [this, key, value](QDBusPendingCallWatcher *call) {
         QDBusPendingReply<QVariantMap> reply = *call;
         call->deleteLater();
@@ -236,8 +237,8 @@ void NetworkTechnology::createInterface()
         connect(m_technology, &NetConnmanTechnologyInterface::PropertyChanged,
                 this, &NetworkTechnology::propertyChanged);
 
-        connect(new QDBusPendingCallWatcher(m_technology->GetProperties(), m_technology),
-                &QDBusPendingCallWatcher::finished,
+        QDBusPendingCallWatcher *pendingCall = new QDBusPendingCallWatcher(m_technology->GetProperties(), m_technology);
+        connect(pendingCall, &QDBusPendingCallWatcher::finished,
                 this, &NetworkTechnology::getPropertiesFinished);
     }
 }
@@ -407,7 +408,7 @@ void NetworkTechnology::propertyChanged(const QString &name, const QDBusVariant 
 
     Q_ASSERT(m_technology);
     m_propertiesCache[name] = tmp;
-    emitPropertyChange(name,tmp);
+    emitPropertyChange(name, tmp);
 }
 
 void NetworkTechnology::scanReply(QDBusPendingCallWatcher *call)

--- a/libconnman-qt/networktechnology.h
+++ b/libconnman-qt/networktechnology.h
@@ -31,7 +31,7 @@ class NetworkTechnology : public QObject
 
 public:
     NetworkTechnology(const QString &path, const QVariantMap &properties, QObject* parent);
-    NetworkTechnology(QObject* parent=0);
+    NetworkTechnology(QObject *parent = nullptr);
 
     virtual ~NetworkTechnology();
 

--- a/libconnman-qt/sessionagent.cpp
+++ b/libconnman-qt/sessionagent.cpp
@@ -23,12 +23,15 @@ Example:
 
   */
 
-SessionAgent::SessionAgent(const QString &path, QObject* parent) :
-    QObject(parent),
-    agentPath(path),
-    m_manager(NetworkManagerFactory::createInstance()),
-    m_session(0)
+SessionAgent::SessionAgent(const QString &path, QObject *parent)
+    : QObject(parent)
+    , agentPath(path)
+    , m_manager(NetworkManager::sharedInstance())
+    , m_session(nullptr)
 {
+    // FIXME: the session mode is long deprecated property on connman, and this
+    // is nasty anyway by controlling a global property based on class instance
+    // here.
     m_manager->setSessionMode(true);
     createSession();
 }

--- a/libconnman-qt/sessionagent.cpp
+++ b/libconnman-qt/sessionagent.cpp
@@ -29,16 +29,11 @@ SessionAgent::SessionAgent(const QString &path, QObject *parent)
     , m_manager(NetworkManager::sharedInstance())
     , m_session(nullptr)
 {
-    // FIXME: the session mode is long deprecated property on connman, and this
-    // is nasty anyway by controlling a global property based on class instance
-    // here.
-    m_manager->setSessionMode(true);
     createSession();
 }
 
 SessionAgent::~SessionAgent()
 {
-    m_manager->setSessionMode(false);
     m_manager->destroySession(agentPath);
 }
 

--- a/libconnman-qt/sessionagent.h
+++ b/libconnman-qt/sessionagent.h
@@ -43,7 +43,7 @@ private Q_SLOTS:
 private:
     QString agentPath;
     QVariantMap sessionSettings;
-    NetworkManager* m_manager;
+    QSharedPointer<NetworkManager> m_manager;
     NetConnmanSessionInterface *m_session;
 
     friend class SessionNotificationAdaptor;

--- a/libconnman-qt/useragent.cpp
+++ b/libconnman-qt/useragent.cpp
@@ -14,18 +14,20 @@ static const char AGENT_PATH[] = "/ConnectivityUserAgent";
 
 UserAgent::UserAgent(QObject* parent) :
     QObject(parent),
-    m_req_data(NULL),
-    m_manager(NetworkManagerFactory::createInstance()),
+    m_req_data(nullptr),
+    m_manager(NetworkManager::sharedInstance()),
     requestType(TYPE_DEFAULT),
     agentPath(QString())
 {
     QString agentpath = QLatin1String("/ConnectivityUserAgent");
     setAgentPath(agentpath);
-    connect(m_manager, SIGNAL(availabilityChanged(bool)),
-            this, SLOT(updateMgrAvailability(bool)));
+    connect(m_manager.data(), &NetworkManager::availabilityChanged,
+            this, &UserAgent::updateMgrAvailability);
+
     requestTimer = new QTimer(this);
     requestTimer->setSingleShot(true);
-    connect(requestTimer,SIGNAL(timeout()),this,SLOT(requestTimeout()));
+    connect(requestTimer, &QTimer::timeout,
+            this, &UserAgent::requestTimeout);
 }
 
 UserAgent::~UserAgent()
@@ -42,7 +44,7 @@ void UserAgent::requestUserInput(ServiceRequestData* data)
 void UserAgent::cancelUserInput()
 {
     delete m_req_data;
-    m_req_data = NULL;
+    m_req_data = nullptr;
     Q_EMIT userInputCanceled();
 }
 
@@ -53,7 +55,7 @@ void UserAgent::reportError(const QString &servicePath, const QString &error)
 
 void UserAgent::sendUserReply(const QVariantMap &input)
 {
-    if (m_req_data == NULL) {
+    if (m_req_data == nullptr) {
         qWarning() << "Got reply for non-existing request";
         return;
     }
@@ -69,7 +71,7 @@ void UserAgent::sendUserReply(const QVariantMap &input)
         QDBusConnection::systemBus().send(error);
     }
     delete m_req_data;
-    m_req_data = NULL;
+    m_req_data = nullptr;
 }
 
 void UserAgent::requestTimeout()

--- a/libconnman-qt/useragent.h
+++ b/libconnman-qt/useragent.h
@@ -16,7 +16,7 @@
 #include <QTimer>
 #include <QElapsedTimer>
 
-class NetworkManager;
+#include "networkmanager.h"
 
 struct ServiceRequestData
 {
@@ -75,7 +75,7 @@ private:
                         const QDBusMessage &message);
 
     ServiceRequestData* m_req_data;
-    NetworkManager* m_manager;
+    QSharedPointer<NetworkManager> m_manager;
     QDBusMessage currentDbusMessage;
     ConnectionRequestType requestType;
     QString agentPath;

--- a/libconnman-qt/vpnmanager.cpp
+++ b/libconnman-qt/vpnmanager.cpp
@@ -42,7 +42,7 @@
 
 static VpnManager* staticInstance = nullptr;
 
-VpnManager* VpnManagerFactory::createInstance()
+static VpnManager* internalCreateInstance()
 {
     qWarning() << "VpnManagerFactory::createInstance/instance() is deprecated. Use VpnManager::sharedInstance() instead.";
 
@@ -52,9 +52,14 @@ VpnManager* VpnManagerFactory::createInstance()
     return staticInstance;
 }
 
+VpnManager* VpnManagerFactory::createInstance()
+{
+    return internalCreateInstance();
+}
+
 VpnManager* VpnManagerFactory::instance()
 {
-    return createInstance();
+    return internalCreateInstance();
 }
 
 // ==========================================================================

--- a/libconnman-qt/vpnmanager.h
+++ b/libconnman-qt/vpnmanager.h
@@ -46,11 +46,10 @@ class VpnConnection;
 // ==========================================================================
 // VpnManagerFactory
 // ==========================================================================
-
+// This class is deprecated
 class VpnManagerFactory : public QObject
 {
     Q_OBJECT
-
     Q_PROPERTY(VpnManager* instance READ instance CONSTANT)
 
 public:
@@ -65,13 +64,12 @@ public:
 class VpnManager : public QObject
 {
     Q_OBJECT
-    Q_DECLARE_PRIVATE(VpnManager)
-    Q_DISABLE_COPY(VpnManager)
-
     Q_PROPERTY(QVector<VpnConnection*> connections READ connections NOTIFY connectionsChanged)
     Q_PROPERTY(bool populated READ populated NOTIFY populatedChanged)
 
 public:
+    static QSharedPointer<VpnManager> sharedInstance();
+
     explicit VpnManager(QObject *parent = nullptr);
     explicit VpnManager(VpnManagerPrivate &dd, QObject *parent);
     virtual ~VpnManager();
@@ -99,6 +97,9 @@ signals:
     void populatedChanged();
 
 private:
+    Q_DECLARE_PRIVATE(VpnManager)
+    Q_DISABLE_COPY(VpnManager)
+
     QScopedPointer<VpnManagerPrivate> d_ptr;
 };
 

--- a/libconnman-qt/vpnmanager.h
+++ b/libconnman-qt/vpnmanager.h
@@ -53,7 +53,7 @@ class VpnManagerFactory : public QObject
     Q_PROPERTY(VpnManager* instance READ instance CONSTANT)
 
 public:
-    static VpnManager* createInstance();
+    Q_DECL_DEPRECATED_X("Use VpnManager::sharedInstance()") static VpnManager* createInstance();
     VpnManager* instance();
 };
 

--- a/libconnman-qt/vpnmodel.cpp
+++ b/libconnman-qt/vpnmodel.cpp
@@ -55,19 +55,21 @@ void VpnModelPrivate::init()
 {
     Q_Q(VpnModel);
 
-    m_manager = VpnManagerFactory::createInstance();
+    m_manager = VpnManager::sharedInstance();
 
     emit q->vpnManagerChanged();
 
-    VpnModel::connect(m_manager, &VpnManager::connectionsChanged, q, &VpnModel::connectionsChanged);
-    VpnModel::connect(m_manager, &VpnManager::populatedChanged, q, &VpnModel::populatedChanged);
+    VpnModel::connect(m_manager.data(), &VpnManager::connectionsChanged, q, &VpnModel::connectionsChanged);
+    VpnModel::connect(m_manager.data(), &VpnManager::populatedChanged, q, &VpnModel::populatedChanged);
 
-    VpnModel::connect(VpnManagerPrivate::get(m_manager), &VpnManagerPrivate::beginConnectionsReset, q, [q, this]() {
+    VpnModel::connect(VpnManagerPrivate::get(m_manager.data()), &VpnManagerPrivate::beginConnectionsReset,
+                      q, [q, this]() {
         q->beginResetModel();
         m_connections.clear();
     });
 
-    VpnModel::connect(VpnManagerPrivate::get(m_manager), &VpnManagerPrivate::endConnectionsReset, q, [q]() {
+    VpnModel::connect(VpnManagerPrivate::get(m_manager.data()), &VpnManagerPrivate::endConnectionsReset,
+                      q, [q]() {
         q->endResetModel();
     });
 
@@ -94,7 +96,7 @@ VpnModel::~VpnModel()
 {
     Q_D(VpnModel);
 
-    disconnect(d->m_manager, &VpnManager::connectionsChanged, this, &VpnModel::connectionsChanged);
+    disconnect(d->m_manager.data(), &VpnManager::connectionsChanged, this, &VpnModel::connectionsChanged);
 }
 
 QHash<int, QByteArray> VpnModel::roleNames() const
@@ -226,7 +228,7 @@ VpnManager * VpnModel::vpnManager() const
 {
     Q_D(const VpnModel);
 
-    return d->m_manager;
+    return d->m_manager.data();
 }
 
 QVariantMap VpnModel::connectionSettings(const QString &path) const

--- a/libconnman-qt/vpnmodel_p.h
+++ b/libconnman-qt/vpnmodel_p.h
@@ -44,7 +44,7 @@ public:
     void init();
 
 public:
-    VpnManager *m_manager;
+    QSharedPointer<VpnManager> m_manager;
     QVector<VpnConnection*> m_connections;
     static const QHash<int, QByteArray> m_roles;
 

--- a/plugin/declarativenetworkmanager.cpp
+++ b/plugin/declarativenetworkmanager.cpp
@@ -1,0 +1,281 @@
+#include "declarativenetworkmanager.h"
+
+#include <QDebug>
+
+DeclarativeNetworkManagerFactory::DeclarativeNetworkManagerFactory(QObject *parent)
+    : QObject(parent)
+    , m_instance(new DeclarativeNetworkManager(this))
+{
+    qWarning() << "QML NetworkManagerFactory is deprecated. Just create NetworkManager instances.";
+}
+
+DeclarativeNetworkManagerFactory::~DeclarativeNetworkManagerFactory()
+{
+}
+
+DeclarativeNetworkManager *DeclarativeNetworkManagerFactory::instance()
+{
+    return m_instance;
+}
+
+DeclarativeNetworkManager::DeclarativeNetworkManager(QObject *parent)
+    : QObject(parent)
+    , m_sharedInstance(NetworkManager::sharedInstance())
+{
+    connect(m_sharedInstance.data(), &NetworkManager::availabilityChanged,
+            this, &DeclarativeNetworkManager::availabilityChanged);
+    connect(m_sharedInstance.data(), &NetworkManager::stateChanged,
+            this, &DeclarativeNetworkManager::stateChanged);
+    connect(m_sharedInstance.data(), &NetworkManager::offlineModeChanged,
+            this, &DeclarativeNetworkManager::offlineModeChanged);
+    connect(m_sharedInstance.data(), &NetworkManager::inputRequestTimeoutChanged,
+            this, &DeclarativeNetworkManager::inputRequestTimeoutChanged);
+    connect(m_sharedInstance.data(), &NetworkManager::defaultRouteChanged,
+            this, &DeclarativeNetworkManager::defaultRouteChanged);
+    connect(m_sharedInstance.data(), &NetworkManager::connectedWifiChanged,
+            this, &DeclarativeNetworkManager::connectedWifiChanged);
+    connect(m_sharedInstance.data(), &NetworkManager::connectedEthernetChanged,
+            this, &DeclarativeNetworkManager::connectedEthernetChanged);
+    connect(m_sharedInstance.data(), &NetworkManager::sessionModeChanged,
+            this, &DeclarativeNetworkManager::sessionModeChanged);
+    connect(m_sharedInstance.data(), &NetworkManager::servicesEnabledChanged,
+            this, &DeclarativeNetworkManager::servicesEnabledChanged);
+    connect(m_sharedInstance.data(), &NetworkManager::technologiesEnabledChanged,
+            this, &DeclarativeNetworkManager::technologiesEnabledChanged);
+    connect(m_sharedInstance.data(), &NetworkManager::validChanged,
+            this, &DeclarativeNetworkManager::validChanged);
+    connect(m_sharedInstance.data(), &NetworkManager::connectedChanged,
+            this, &DeclarativeNetworkManager::connectedChanged);
+    connect(m_sharedInstance.data(), &NetworkManager::connectingChanged,
+            this, &DeclarativeNetworkManager::connectingChanged);
+    connect(m_sharedInstance.data(), &NetworkManager::connectingWifiChanged,
+            this, &DeclarativeNetworkManager::connectingWifiChanged);
+    connect(m_sharedInstance.data(), &NetworkManager::technologiesChanged,
+            this, &DeclarativeNetworkManager::technologiesChanged);
+    connect(m_sharedInstance.data(), &NetworkManager::servicesChanged,
+            this, &DeclarativeNetworkManager::servicesChanged);
+    connect(m_sharedInstance.data(), &NetworkManager::savedServicesChanged,
+            this, &DeclarativeNetworkManager::savedServicesChanged);
+    connect(m_sharedInstance.data(), &NetworkManager::wifiServicesChanged,
+            this, &DeclarativeNetworkManager::wifiServicesChanged);
+    connect(m_sharedInstance.data(), &NetworkManager::cellularServicesChanged,
+            this, &DeclarativeNetworkManager::cellularServicesChanged);
+    connect(m_sharedInstance.data(), &NetworkManager::ethernetServicesChanged,
+            this, &DeclarativeNetworkManager::ethernetServicesChanged);
+    connect(m_sharedInstance.data(), &NetworkManager::availableServicesChanged,
+            this, &DeclarativeNetworkManager::availableServicesChanged);
+    connect(m_sharedInstance.data(), &NetworkManager::servicesListChanged,
+            this, &DeclarativeNetworkManager::servicesListChanged);
+    connect(m_sharedInstance.data(), &NetworkManager::serviceAdded,
+            this, &DeclarativeNetworkManager::serviceAdded);
+    connect(m_sharedInstance.data(), &NetworkManager::serviceRemoved,
+            this, &DeclarativeNetworkManager::serviceRemoved);
+    connect(m_sharedInstance.data(), &NetworkManager::serviceCreated,
+            this, &DeclarativeNetworkManager::serviceCreated);
+    connect(m_sharedInstance.data(), &NetworkManager::serviceCreationFailed,
+            this, &DeclarativeNetworkManager::serviceCreationFailed);
+}
+
+DeclarativeNetworkManager::~DeclarativeNetworkManager()
+{
+}
+
+bool DeclarativeNetworkManager::isAvailable() const
+{
+    return m_sharedInstance->isAvailable();
+}
+
+QString DeclarativeNetworkManager::state() const
+{
+    return m_sharedInstance->state();
+}
+
+bool DeclarativeNetworkManager::offlineMode() const
+{
+    return m_sharedInstance->offlineMode();
+}
+
+NetworkService* DeclarativeNetworkManager::defaultRoute() const
+{
+    return m_sharedInstance->defaultRoute();
+}
+
+NetworkService* DeclarativeNetworkManager::connectedWifi() const
+{
+    return m_sharedInstance->connectedWifi();
+}
+
+NetworkService *DeclarativeNetworkManager::connectedEthernet() const
+{
+    return m_sharedInstance->connectedEthernet();
+}
+
+bool DeclarativeNetworkManager::connectingWifi() const
+{
+    return m_sharedInstance->connectingWifi();
+}
+
+bool DeclarativeNetworkManager::sessionMode() const
+{
+    return m_sharedInstance->sessionMode();
+}
+
+uint DeclarativeNetworkManager::inputRequestTimeout() const
+{
+    return m_sharedInstance->inputRequestTimeout();
+}
+
+bool DeclarativeNetworkManager::servicesEnabled() const
+{
+    return m_sharedInstance->servicesEnabled();
+}
+
+void DeclarativeNetworkManager::setServicesEnabled(bool enabled)
+{
+    m_sharedInstance->setServicesEnabled(enabled);
+}
+
+bool DeclarativeNetworkManager::technologiesEnabled() const
+{
+    return m_sharedInstance->technologiesEnabled();
+}
+
+void DeclarativeNetworkManager::setTechnologiesEnabled(bool enabled)
+{
+    m_sharedInstance->setTechnologiesEnabled(enabled);
+}
+
+bool DeclarativeNetworkManager::isValid() const
+{
+    return m_sharedInstance->isValid();
+}
+
+bool DeclarativeNetworkManager::connected() const
+{
+    return m_sharedInstance->connected();
+}
+
+bool DeclarativeNetworkManager::connecting() const
+{
+    return m_sharedInstance->connecting();
+}
+
+QString DeclarativeNetworkManager::wifiTechnologyPath() const
+{
+    return m_sharedInstance->wifiTechnologyPath();
+}
+
+QString DeclarativeNetworkManager::cellularTechnologyPath() const
+{
+    return m_sharedInstance->cellularTechnologyPath();
+}
+
+QString DeclarativeNetworkManager::bluetoothTechnologyPath() const
+{
+    return m_sharedInstance->bluetoothTechnologyPath();
+}
+
+QString DeclarativeNetworkManager::gpsTechnologyPath() const
+{
+    return m_sharedInstance->gpsTechnologyPath();
+}
+
+QString DeclarativeNetworkManager::ethernetTechnologyPath() const
+{
+    return m_sharedInstance->ethernetTechnologyPath();
+}
+
+QStringList DeclarativeNetworkManager::servicesList(const QString &tech)
+{
+    return m_sharedInstance->servicesList(tech);
+}
+
+QStringList DeclarativeNetworkManager::savedServicesList(const QString &tech)
+{
+    return m_sharedInstance->savedServicesList(tech);
+}
+
+QStringList DeclarativeNetworkManager::availableServices(const QString &tech)
+{
+    return m_sharedInstance->availableServices(tech);
+}
+
+QStringList DeclarativeNetworkManager::technologiesList()
+{
+    return m_sharedInstance->technologiesList();
+}
+
+QString DeclarativeNetworkManager::technologyPathForService(const QString &path)
+{
+    return m_sharedInstance->technologyPathForService(path);
+}
+
+QString DeclarativeNetworkManager::technologyPathForType(const QString &type)
+{
+    return m_sharedInstance->technologyPathForType(type);
+}
+
+void DeclarativeNetworkManager::resetCountersForType(const QString &type)
+{
+    m_sharedInstance->resetCountersForType(type);
+}
+
+void DeclarativeNetworkManager::setOfflineModeProperty(bool offlineMode)
+{
+    m_sharedInstance->setOfflineMode(offlineMode);
+}
+
+void DeclarativeNetworkManager::setSessionModeProperty(bool sessionMode)
+{
+    m_sharedInstance->setSessionMode(sessionMode);
+}
+
+void DeclarativeNetworkManager::setOfflineMode(bool offlineMode)
+{
+    qWarning() << "NetworkManager:setOfflineMode() is deprecated. Assign to property";
+    setOfflineModeProperty(offlineMode);
+}
+
+void DeclarativeNetworkManager::setSessionMode(bool sessionMode)
+{
+    qWarning() << "NetworkManager:setSessionMode() is deprecated. Assign to property";
+    setSessionModeProperty(sessionMode);
+}
+
+void DeclarativeNetworkManager::registerAgent(const QString &path)
+{
+    m_sharedInstance->registerAgent(path);
+}
+
+void DeclarativeNetworkManager::unregisterAgent(const QString &path)
+{
+    m_sharedInstance->unregisterAgent(path);
+}
+
+void DeclarativeNetworkManager::registerCounter(const QString &path, quint32 accuracy, quint32 period)
+{
+    m_sharedInstance->registerCounter(path, accuracy, period);
+}
+
+void DeclarativeNetworkManager::unregisterCounter(const QString &path)
+{
+    m_sharedInstance->unregisterCounter(path);
+}
+
+bool DeclarativeNetworkManager::createService(
+        const QVariantMap &settings,
+        const QString &tech,
+        const QString &service,
+        const QString &device)
+{
+    return m_sharedInstance->createService(settings, tech, service, device);
+}
+
+QString DeclarativeNetworkManager::createServiceSync(
+        const QVariantMap &settings,
+        const QString &tech,
+        const QString &service,
+        const QString &device)
+{
+    return m_sharedInstance->createServiceSync(settings, tech, service, device);
+}

--- a/plugin/declarativenetworkmanager.h
+++ b/plugin/declarativenetworkmanager.h
@@ -1,0 +1,150 @@
+#ifndef DECLARATIVENETWORKMANAGER_H
+#define DECLARATIVENETWORKMANAGER_H
+
+#include "networkmanager.h"
+
+class DeclarativeNetworkManager;
+
+class DeclarativeNetworkManagerFactory : public QObject
+{
+    Q_OBJECT
+    Q_PROPERTY(DeclarativeNetworkManager* instance READ instance CONSTANT)
+public:
+    DeclarativeNetworkManagerFactory(QObject *parent = nullptr);
+    ~DeclarativeNetworkManagerFactory();
+
+    DeclarativeNetworkManager *instance();
+
+private:
+    DeclarativeNetworkManager *m_instance;
+};
+
+class DeclarativeNetworkManager: public QObject
+{
+    Q_OBJECT
+    Q_PROPERTY(bool available READ isAvailable NOTIFY availabilityChanged)
+    Q_PROPERTY(QString state READ state NOTIFY stateChanged)
+    Q_PROPERTY(bool offlineMode READ offlineMode WRITE setOfflineModeProperty NOTIFY offlineModeChanged)
+    Q_PROPERTY(NetworkService* defaultRoute READ defaultRoute NOTIFY defaultRouteChanged)
+    Q_PROPERTY(NetworkService* connectedWifi READ connectedWifi NOTIFY connectedWifiChanged)
+    Q_PROPERTY(NetworkService* connectedEthernet READ connectedEthernet NOTIFY connectedEthernetChanged)
+    Q_PROPERTY(bool connectingWifi READ connectingWifi NOTIFY connectingWifiChanged)
+
+    Q_PROPERTY(bool sessionMode READ sessionMode WRITE setSessionModeProperty NOTIFY sessionModeChanged)
+    Q_PROPERTY(uint inputRequestTimeout READ inputRequestTimeout NOTIFY inputRequestTimeoutChanged)
+
+    Q_PROPERTY(bool servicesEnabled READ servicesEnabled WRITE setServicesEnabled NOTIFY servicesEnabledChanged)
+    Q_PROPERTY(bool technologiesEnabled READ technologiesEnabled WRITE setTechnologiesEnabled NOTIFY technologiesEnabledChanged)
+    Q_PROPERTY(bool valid READ isValid NOTIFY validChanged)
+
+    Q_PROPERTY(bool connected READ connected NOTIFY connectedChanged)
+    Q_PROPERTY(bool connecting READ connecting NOTIFY connectingChanged)
+
+    Q_PROPERTY(QString WifiTechnology READ wifiTechnologyPath CONSTANT)
+    Q_PROPERTY(QString CellularTechnology READ cellularTechnologyPath CONSTANT)
+    Q_PROPERTY(QString BluetoothTechnology READ bluetoothTechnologyPath CONSTANT)
+    Q_PROPERTY(QString GpsTechnology READ gpsTechnologyPath CONSTANT)
+    Q_PROPERTY(QString EthernetTechnology READ ethernetTechnologyPath CONSTANT)
+
+public:
+    DeclarativeNetworkManager(QObject *parent = 0);
+    virtual ~DeclarativeNetworkManager();
+
+    bool isAvailable() const;
+    QString state() const;
+    bool offlineMode() const;
+    NetworkService* defaultRoute() const;
+    NetworkService* connectedWifi() const;
+    NetworkService *connectedEthernet() const;
+    bool connectingWifi() const;
+
+    bool sessionMode() const;
+    uint inputRequestTimeout() const;
+
+    bool servicesEnabled() const;
+    void setServicesEnabled(bool enabled);
+
+    bool technologiesEnabled() const;
+    void setTechnologiesEnabled(bool enabled);
+
+    bool isValid() const;
+    bool connected() const;
+    bool connecting() const;
+
+    QString wifiTechnologyPath() const;
+    QString cellularTechnologyPath() const;
+    QString bluetoothTechnologyPath() const;
+    QString gpsTechnologyPath() const;
+    QString ethernetTechnologyPath() const;
+
+    Q_INVOKABLE QStringList servicesList(const QString &tech);
+    Q_INVOKABLE QStringList savedServicesList(const QString &tech = QString());
+    Q_INVOKABLE QStringList availableServices(const QString &tech = QString());
+    Q_INVOKABLE QStringList technologiesList();
+    Q_INVOKABLE QString technologyPathForService(const QString &path);
+    Q_INVOKABLE QString technologyPathForType(const QString &type);
+
+    Q_INVOKABLE void resetCountersForType(const QString &type);
+    // Note: getTechnology() skipped, it was deprecated and use discouraged on qml
+
+    void setOfflineModeProperty(bool offlineMode);
+    void setSessionModeProperty(bool sessionMode);
+
+public Q_SLOTS:
+    // deprecated, should assign property
+    void setOfflineMode(bool offlineMode);
+    void setSessionMode(bool sessionMode);
+
+    void registerAgent(const QString &path);
+    void unregisterAgent(const QString &path);
+    void registerCounter(const QString &path, quint32 accuracy, quint32 period);
+    void unregisterCounter(const QString &path);
+
+    // createSession skipped here because the QDBusObjectPath wouldn't be usable in QML.
+    // destroySession skipped too for symmetry
+    bool createService(
+            const QVariantMap &settings,
+            const QString &tech = QString(),
+            const QString &service = QString(),
+            const QString &device = QString());
+    QString createServiceSync(
+            const QVariantMap &settings,
+            const QString &tech = QString(),
+            const QString &service = QString(),
+            const QString &device = QString());
+
+Q_SIGNALS:
+    void availabilityChanged();
+    void stateChanged();
+    void offlineModeChanged();
+    void inputRequestTimeoutChanged();
+    void defaultRouteChanged();
+    void connectedWifiChanged();
+    void connectedEthernetChanged();
+    void sessionModeChanged();
+    void servicesEnabledChanged();
+    void technologiesEnabledChanged();
+    void validChanged();
+    void connectedChanged();
+    void connectingChanged();
+    void connectingWifiChanged();
+
+    // following not property notifiers
+    void technologiesChanged();
+    void servicesChanged();
+    void savedServicesChanged();
+    void wifiServicesChanged();
+    void cellularServicesChanged();
+    void ethernetServicesChanged();
+    void availableServicesChanged();
+    void servicesListChanged();
+    void serviceAdded(const QString &servicePath);
+    void serviceRemoved(const QString &servicePath);
+    void serviceCreated(const QString &servicePath);
+    void serviceCreationFailed(const QString &error);
+
+private:
+    QSharedPointer<NetworkManager> m_sharedInstance;
+};
+
+#endif

--- a/plugin/plugin.cpp
+++ b/plugin/plugin.cpp
@@ -4,7 +4,7 @@
  * Copyright (c) 2019 Open Mobile Platform LLC.
  *
  * This program is licensed under the terms and conditions of the
- * Apache License, version 2.0.  The full text of the Apache License is at 
+ * Apache License, version 2.0.  The full text of the Apache License is at
  * http://www.apache.org/licenses/LICENSE-2.0
  */
 
@@ -49,18 +49,18 @@ void ConnmanPlugin::registerTypes(const char *uri)
         qWarning() << "MeeGo.Connman QML module name is deprecated and subject for removal. Please adapt code to \"import Connman\".";
     }
 
-    qmlRegisterType<NetworkService>(uri,0,2,"NetworkService");
-    qmlRegisterType<TechnologyModel>(uri,0,2,"TechnologyModel");
-    qmlRegisterType<SavedServiceModel>(uri,0,2,"SavedServiceModel");
-    qmlRegisterType<UserAgent>(uri,0,2,"UserAgent");
-    qmlRegisterType<ClockModel>(uri,0,2,"ClockModel");
-    qmlRegisterType<NetworkSession>(uri,0,2,"NetworkSession");
-    qmlRegisterType<NetworkManager>(uri,0,2,"NetworkManager");
-    qmlRegisterType<NetworkManagerFactory>(uri,0,2,"NetworkManagerFactory");
-    qmlRegisterType<NetworkTechnology>(uri,0,2,"NetworkTechnology");
-    qmlRegisterType<Counter>(uri,0,2,"NetworkCounter");
-    qmlRegisterSingletonType<VpnManager>(uri,0,2,"VpnManager", singleton_api_factory<VpnManager>);
-    qmlRegisterType<VpnConnection>(uri,0,2,"VpnConnection");
+    qmlRegisterType<NetworkService>(uri, 0, 2, "NetworkService");
+    qmlRegisterType<TechnologyModel>(uri, 0, 2, "TechnologyModel");
+    qmlRegisterType<SavedServiceModel>(uri, 0, 2, "SavedServiceModel");
+    qmlRegisterType<UserAgent>(uri, 0, 2, "UserAgent");
+    qmlRegisterType<ClockModel>(uri, 0, 2, "ClockModel");
+    qmlRegisterType<NetworkSession>(uri, 0, 2, "NetworkSession");
+    qmlRegisterType<NetworkManager>(uri, 0, 2, "NetworkManager");
+    qmlRegisterType<NetworkManagerFactory>(uri, 0, 2, "NetworkManagerFactory");
+    qmlRegisterType<NetworkTechnology>(uri, 0, 2, "NetworkTechnology");
+    qmlRegisterType<Counter>(uri, 0, 2, "NetworkCounter");
+    qmlRegisterSingletonType<VpnManager>(uri, 0, 2, "VpnManager", singleton_api_factory<VpnManager>);
+    qmlRegisterType<VpnConnection>(uri, 0, 2, "VpnConnection");
     qmlRegisterSingletonType<VpnModel>(uri, 0, 2, "VpnModel", singleton_api_factory<VpnModel>);
 }
 

--- a/plugin/plugin.cpp
+++ b/plugin/plugin.cpp
@@ -16,6 +16,7 @@
 
 #include <networkservice.h>
 #include <clockmodel.h>
+#include "declarativenetworkmanager.h"
 #include "technologymodel.h"
 #include "savedservicemodel.h"
 #include "useragent.h"
@@ -55,8 +56,8 @@ void ConnmanPlugin::registerTypes(const char *uri)
     qmlRegisterType<UserAgent>(uri, 0, 2, "UserAgent");
     qmlRegisterType<ClockModel>(uri, 0, 2, "ClockModel");
     qmlRegisterType<NetworkSession>(uri, 0, 2, "NetworkSession");
-    qmlRegisterType<NetworkManager>(uri, 0, 2, "NetworkManager");
-    qmlRegisterType<NetworkManagerFactory>(uri, 0, 2, "NetworkManagerFactory");
+    qmlRegisterType<DeclarativeNetworkManager>(uri, 0, 2, "NetworkManager");
+    qmlRegisterType<DeclarativeNetworkManagerFactory>(uri, 0, 2, "NetworkManagerFactory");
     qmlRegisterType<NetworkTechnology>(uri, 0, 2, "NetworkTechnology");
     qmlRegisterType<Counter>(uri, 0, 2, "NetworkCounter");
     qmlRegisterSingletonType<VpnManager>(uri, 0, 2, "VpnManager", singleton_api_factory<VpnManager>);

--- a/plugin/plugin.pro
+++ b/plugin/plugin.pro
@@ -2,8 +2,18 @@ TARGET=ConnmanQtDeclarative
 TEMPLATE = lib
 QT += dbus
 CONFIG += plugin
-SOURCES = plugin.cpp technologymodel.cpp savedservicemodel.cpp
-HEADERS = technologymodel.h savedservicemodel.h
+
+SOURCES = \
+    plugin.cpp \
+    technologymodel.cpp \
+    savedservicemodel.cpp \
+    declarativenetworkmanager.cpp
+
+HEADERS = \
+    technologymodel.h \
+    savedservicemodel.h \
+    declarativenetworkmanager.h
+
 INCLUDEPATH += ../libconnman-qt
 LIBS += -L../libconnman-qt
 QT -= gui

--- a/plugin/plugins.qmltypes
+++ b/plugin/plugins.qmltypes
@@ -102,7 +102,7 @@ Module {
         }
     }
     Component {
-        name: "NetworkManager"
+        name: "DeclarativeNetworkManager"
         prototype: "QObject"
         exports: ["Connman/NetworkManager 0.2"]
         exportMetaObjectRevisions: [0]
@@ -111,8 +111,8 @@ Module {
         Property { name: "offlineMode"; type: "bool" }
         Property { name: "defaultRoute"; type: "NetworkService"; isReadonly: true; isPointer: true }
         Property { name: "connectedWifi"; type: "NetworkService"; isReadonly: true; isPointer: true }
-        Property { name: "connectingWifi"; type: "bool"; isReadonly: true }
         Property { name: "connectedEthernet"; type: "NetworkService"; isReadonly: true; isPointer: true }
+        Property { name: "connectingWifi"; type: "bool"; isReadonly: true }
         Property { name: "sessionMode"; type: "bool" }
         Property { name: "inputRequestTimeout"; type: "uint"; isReadonly: true }
         Property { name: "servicesEnabled"; type: "bool" }
@@ -125,10 +125,7 @@ Module {
         Property { name: "BluetoothTechnology"; type: "string"; isReadonly: true }
         Property { name: "GpsTechnology"; type: "string"; isReadonly: true }
         Property { name: "EthernetTechnology"; type: "string"; isReadonly: true }
-        Signal {
-            name: "availabilityChanged"
-            Parameter { name: "available"; type: "bool" }
-        }
+        Signal { name: "availabilityChanged" }
         Signal {
             name: "stateChanged"
             Parameter { name: "state"; type: "string" }
@@ -154,10 +151,7 @@ Module {
             name: "sessionModeChanged"
             Parameter { type: "bool" }
         }
-        Signal {
-            name: "servicesListChanged"
-            Parameter { name: "list"; type: "QStringList" }
-        }
+        Signal { name: "servicesListChanged" }
         Signal {
             name: "serviceAdded"
             Parameter { name: "servicePath"; type: "string" }
@@ -183,6 +177,10 @@ Module {
             Parameter { name: "offlineMode"; type: "bool" }
         }
         Method {
+            name: "setSessionMode"
+            Parameter { name: "sessionMode"; type: "bool" }
+        }
+        Method {
             name: "registerAgent"
             Parameter { name: "path"; type: "string" }
         }
@@ -201,16 +199,6 @@ Module {
             Parameter { name: "path"; type: "string" }
         }
         Method {
-            name: "createSession"
-            type: "QDBusObjectPath"
-            Parameter { name: "settings"; type: "QVariantMap" }
-            Parameter { name: "sessionNotifierPath"; type: "string" }
-        }
-        Method {
-            name: "destroySession"
-            Parameter { name: "sessionAgentPath"; type: "string" }
-        }
-        Method {
             name: "createService"
             type: "bool"
             Parameter { name: "settings"; type: "QVariantMap" }
@@ -261,15 +249,6 @@ Module {
             name: "createServiceSync"
             type: "string"
             Parameter { name: "settings"; type: "QVariantMap" }
-        }
-        Method {
-            name: "setSessionMode"
-            Parameter { name: "sessionMode"; type: "bool" }
-        }
-        Method {
-            name: "getTechnology"
-            type: "NetworkTechnology*"
-            Parameter { name: "type"; type: "string" }
         }
         Method {
             name: "servicesList"
@@ -305,11 +284,16 @@ Module {
         }
     }
     Component {
-        name: "NetworkManagerFactory"
+        name: "DeclarativeNetworkManagerFactory"
         prototype: "QObject"
         exports: ["Connman/NetworkManagerFactory 0.2"]
         exportMetaObjectRevisions: [0]
-        Property { name: "instance"; type: "NetworkManager"; isReadonly: true; isPointer: true }
+        Property {
+            name: "instance"
+            type: "DeclarativeNetworkManager"
+            isReadonly: true
+            isPointer: true
+        }
     }
     Component {
         name: "NetworkService"

--- a/plugin/savedservicemodel.cpp
+++ b/plugin/savedservicemodel.cpp
@@ -42,11 +42,15 @@ bool compareManagedServices(NetworkService *a, NetworkService *b)
 }
 
 SavedServiceModel::SavedServiceModel(QAbstractListModel* parent)
-:   QAbstractListModel(parent), m_sort(false), m_groupByCategory(false)
+    : QAbstractListModel(parent)
+    , m_sort(false)
+    , m_groupByCategory(false)
 {
-    m_manager = NetworkManagerFactory::createInstance();
-    connect(m_manager, SIGNAL(technologiesChanged()), SLOT(updateServiceList()));
-    connect(m_manager, SIGNAL(servicesChanged()), SLOT(updateServiceList()));
+    m_manager = NetworkManager::sharedInstance();
+    connect(m_manager.data(), &NetworkManager::technologiesChanged,
+            this, &SavedServiceModel::updateServiceList);
+    connect(m_manager.data(), &NetworkManager::servicesChanged,
+            this, &SavedServiceModel::updateServiceList);
 }
 
 SavedServiceModel::~SavedServiceModel()

--- a/plugin/savedservicemodel.h
+++ b/plugin/savedservicemodel.h
@@ -60,7 +60,7 @@ Q_SIGNALS:
 
 private:
     QString m_techname;
-    NetworkManager* m_manager;
+    QSharedPointer<NetworkManager> m_manager;
     QVector<NetworkService *> m_services;
     bool m_sort;
     bool m_groupByCategory;

--- a/plugin/technologymodel.cpp
+++ b/plugin/technologymodel.cpp
@@ -13,27 +13,22 @@
 
 TechnologyModel::TechnologyModel(QAbstractListModel* parent)
   : QAbstractListModel(parent),
-    m_manager(NULL),
-    m_tech(NULL),
+    m_tech(nullptr),
     m_scanning(false),
     m_changesInhibited(false),
     m_uneffectedChanges(false),
     m_filter(AvailableServices)
 {
-    m_manager = NetworkManagerFactory::createInstance();
+    m_manager = NetworkManager::sharedInstance();
 
-    connect(m_manager, SIGNAL(availabilityChanged(bool)),
-            this, SLOT(managerAvailabilityChanged(bool)));
+    connect(m_manager.data(), &NetworkManager::availabilityChanged,
+            this, &TechnologyModel::managerAvailabilityChanged);
 
-    connect(m_manager,
-            SIGNAL(technologiesChanged()),
-            this,
-            SLOT(updateTechnologies()));
+    connect(m_manager.data(), &NetworkManager::technologiesChanged,
+            this, &TechnologyModel::updateTechnologies);
 
-    connect(m_manager,
-            SIGNAL(servicesChanged()),
-            this,
-            SLOT(updateServiceList()));
+    connect(m_manager.data(), &NetworkManager::servicesChanged,
+            this, &TechnologyModel::updateServiceList);
 }
 
 TechnologyModel::~TechnologyModel()

--- a/plugin/technologymodel.h
+++ b/plugin/technologymodel.h
@@ -83,7 +83,7 @@ Q_SIGNALS:
 
 private:
     QString m_techname;
-    NetworkManager* m_manager;
+    QSharedPointer<NetworkManager> m_manager;
     NetworkTechnology* m_tech;
     QVector<NetworkService *> m_services;
     bool m_scanning;

--- a/tests/testbase.h
+++ b/tests/testbase.h
@@ -318,7 +318,6 @@ inline QVariantMap TestBase::defaultManagerProperties()
 
     properties["State"] = "offline";
     properties["OfflineMode"] = false;
-    properties["SessionMode"] = true;
 
     initialized = true;
 

--- a/tests/ut_agent.cpp
+++ b/tests/ut_agent.cpp
@@ -342,7 +342,6 @@ QVariantMap UtAgent::ManagerMock::GetProperties() const
     QVariantMap properties;
     properties["State"] = "offline";
     properties["OfflineMode"] = false;
-    properties["SessionMode"] = true;
     return properties;
 }
 

--- a/tests/ut_manager.cpp
+++ b/tests/ut_manager.cpp
@@ -170,7 +170,6 @@ void UtManager::testWriteProperties_data()
     QTest::addColumn<QVariant>("newValue");
 
     QTest::newRow("offlineMode") << QVariant(true);
-    QTest::newRow("sessionMode") << QVariant(false);
 }
 
 void UtManager::testWriteProperties()
@@ -391,7 +390,7 @@ QVariantMap UtManager::ManagerMock::GetProperties() const
 void UtManager::ManagerMock::SetProperty(const QString &name, const QDBusVariant &value,
         const QDBusMessage &message)
 {
-    if (name != "OfflineMode" && name != "SessionMode") {
+    if (name != "OfflineMode") {
         const QString err = QString("Property not writable '%1'").arg(name);
         qWarning("%s: %s", Q_FUNC_INFO, qPrintable(err));
         bus().send(message.createErrorReply(QDBusError::Failed, err));

--- a/tests/ut_session.cpp
+++ b/tests/ut_session.cpp
@@ -63,7 +63,6 @@ signals:
     Q_SCRIPTABLE void PropertyChanged(const QString &name, const QVariant &value);
 
 private:
-    bool m_sessionMode;
     int m_sessionNextIndex;
     QMap<QString, SessionMock *> m_sessions;
 };
@@ -272,7 +271,6 @@ QObject *UtSession::findSessionNotificationAdaptor() const
 
 UtSession::ManagerMock::ManagerMock()
     : MainObjectMock("net.connman", "/"),
-      m_sessionMode(false),
       m_sessionNextIndex(0)
 {
 }
@@ -282,22 +280,16 @@ QVariantMap UtSession::ManagerMock::GetProperties() const
     QVariantMap properties;
     properties["State"] = "offline";
     properties["OfflineMode"] = false;
-    properties["SessionMode"] = m_sessionMode;
     return properties;
 }
 
 void UtSession::ManagerMock::SetProperty(const QString &name, const QVariant &value,
         const QDBusMessage &message)
 {
-    if (name == "SessionMode") {
-        m_sessionMode = value.toBool();
-        Q_EMIT PropertyChanged(name, value);
-    } else {
-        const QString err = QString("Property '%1' not handled").arg(name);
-        qWarning("%s: %s", Q_FUNC_INFO, qPrintable(err));
-        bus().send(message.createErrorReply(QDBusError::Failed, err));
-        return;
-    }
+    const QString err = QString("Property '%1' not handled").arg(name);
+    qWarning("%s: %s", Q_FUNC_INFO, qPrintable(err));
+    bus().send(message.createErrorReply(QDBusError::Failed, err));
+    return;
 }
 
 ConnmanObjectList UtSession::ManagerMock::GetTechnologies() const


### PR DESCRIPTION
Bunch of commits here allowing to limit the number of NetworkManager instances in a process to ideally just one.

More details on specific commits but on high level included here:
- Deprecated and removed functionality on technologies / servicesEnabled which wasn't working on shared instances earlier either.
-  Deprecated the factory classes and NetworkManager::instance() which was returning a plain pointer. These APIs were leaking memory and, maybe even worse, leaving instances tracking connman until the process quit.
-  Created a separate proxy QML class for NetworkManager, allowing to skip any reason for using factories in QML.

For minor API changes some details which shouldn't have been used/usable in QML weren't copied there. On some classes the ABI changed too due to internal member variables in class headers. To me that's a sign of no stability promised.