### PR TITLE
Code enhancements. JB#61659

### DIFF
--- a/libconnman-qt/clockmodel.cpp
+++ b/libconnman-qt/clockmodel.cpp
@@ -14,71 +14,90 @@
 #define CONNMAN_CLOCK_INTERFACE CONNMAN_SERVICE ".Clock"
 
 #define SET_CONNMAN_PROPERTY(key, val) \
-        if (!mClockProxy) { \
+        if (!d_ptr->mClockProxy) { \
             qCritical("ClockModel: SetProperty: not connected to connman"); \
         } else { \
-            QDBusPendingReply<> reply = mClockProxy->SetProperty(key, QDBusVariant(val)); \
+            QDBusPendingReply<> reply = d_ptr->mClockProxy->SetProperty(key, QDBusVariant(val)); \
             QDBusPendingCallWatcher *watcher = new QDBusPendingCallWatcher(reply, this); \
             connect(watcher, SIGNAL(finished(QDBusPendingCallWatcher*)), \
                     this, SLOT(setPropertyFinished(QDBusPendingCallWatcher*))); \
         }
 
-ClockModel::ClockModel() :
-    mClockProxy(0)
+class ClockModelPrivate
 {
-    QTimer::singleShot(0,this,SLOT(connectToConnman()));
+public:
+    ClockModelPrivate();
+
+    NetConnmanClockInterface *mClockProxy;
+    QString mTimezone;
+    QString mTimezoneUpdates;
+    QString mTimeUpdates;
+    QStringList mTimeservers;
+};
+
+ClockModelPrivate::ClockModelPrivate()
+    : mClockProxy(nullptr)
+{
+}
+
+ClockModel::ClockModel()
+    : d_ptr(new ClockModelPrivate)
+{
+    QTimer::singleShot(0, this, SLOT(connectToConnman()));
+}
+
+ClockModel::~ClockModel()
+{
+    delete d_ptr;
+    d_ptr = nullptr;
 }
 
 void ClockModel::connectToConnman()
 {
-    if (mClockProxy && mClockProxy->isValid())
+    if (d_ptr->mClockProxy && d_ptr->mClockProxy->isValid())
         return;
 
-    mClockProxy = new NetConnmanClockInterface(CONNMAN_SERVICE, "/", QDBusConnection::systemBus(),
-        this);
+    d_ptr->mClockProxy = new NetConnmanClockInterface(CONNMAN_SERVICE, "/", QDBusConnection::systemBus(), this);
 
-    if (!mClockProxy->isValid()) {
+    if (!d_ptr->mClockProxy->isValid()) {
         qCritical("ClockModel: unable to connect to connman");
-        delete mClockProxy;
-        mClockProxy = NULL;
+        delete d_ptr->mClockProxy;
+        d_ptr->mClockProxy = nullptr;
         return;
     }
 
-    QDBusPendingReply<QVariantMap> reply = mClockProxy->GetProperties();
+    QDBusPendingReply<QVariantMap> reply = d_ptr->mClockProxy->GetProperties();
     QDBusPendingCallWatcher *watcher = new QDBusPendingCallWatcher(reply, this);
-    connect(watcher,
-            SIGNAL(finished(QDBusPendingCallWatcher*)),
-            this,
-            SLOT(getPropertiesFinished(QDBusPendingCallWatcher*)));
+    connect(watcher, SIGNAL(finished(QDBusPendingCallWatcher*)),
+            this, SLOT(getPropertiesFinished(QDBusPendingCallWatcher*)));
 
-    connect(mClockProxy,
-            SIGNAL(PropertyChanged(const QString&, const QDBusVariant&)),
-            this,
-            SLOT(propertyChanged(const QString&, const QDBusVariant&)));
+    connect(d_ptr->mClockProxy, SIGNAL(PropertyChanged(const QString&, const QDBusVariant&)),
+            this, SLOT(propertyChanged(const QString&, const QDBusVariant&)));
 }
 
 void ClockModel::getPropertiesFinished(QDBusPendingCallWatcher *call)
 {
     QDBusPendingReply<QVariantMap> reply = *call;
+
     if (reply.isError()) {
         qCritical() << "ClockModel: getProperties: " << reply.error().name() << reply.error().message();
     } else {
         QVariantMap properties = reply.value();
 
         if (properties.contains(QLatin1String("Timezone"))) {
-            mTimezone = properties.value("Timezone").toString();
+            d_ptr->mTimezone = properties.value("Timezone").toString();
             Q_EMIT timezoneChanged();
         }
         if (properties.contains(QLatin1String("TimezoneUpdates"))) {
-            mTimezoneUpdates = properties.value("TimezoneUpdates").toString();
+            d_ptr->mTimezoneUpdates = properties.value("TimezoneUpdates").toString();
             Q_EMIT timezoneUpdatesChanged();
         }
         if (properties.contains(QLatin1String("TimeUpdates"))) {
-            mTimeUpdates = properties.value("TimeUpdates").toString();
+            d_ptr->mTimeUpdates = properties.value("TimeUpdates").toString();
             Q_EMIT timeUpdatesChanged();
         }
         if (properties.contains(QLatin1String("Timeservers"))) {
-            mTimeservers = properties.value("Timeservers").toStringList();
+            d_ptr->mTimeservers = properties.value("Timeservers").toStringList();
             Q_EMIT timeserversChanged();
         }
     }
@@ -97,23 +116,23 @@ void ClockModel::setPropertyFinished(QDBusPendingCallWatcher *call)
 void ClockModel::propertyChanged(const QString &name, const QDBusVariant &value)
 {
     if (name == "Timezone") {
-        mTimezone = value.variant().toString();
+        d_ptr->mTimezone = value.variant().toString();
         Q_EMIT timezoneChanged();
     } else if (name == "TimezoneUpdates") {
-        mTimezoneUpdates = value.variant().toString();
+        d_ptr->mTimezoneUpdates = value.variant().toString();
         Q_EMIT timezoneUpdatesChanged();
     } else if (name == "TimeUpdates") {
-        mTimeUpdates = value.variant().toString();
+        d_ptr->mTimeUpdates = value.variant().toString();
         Q_EMIT timeUpdatesChanged();
     } else if (name == "Timeservers") {
-        mTimeservers = value.variant().toStringList();
+        d_ptr->mTimeservers = value.variant().toStringList();
         Q_EMIT timeserversChanged();
     }
 }
 
 QString ClockModel::timezone() const
 {
-    return mTimezone;
+    return d_ptr->mTimezone;
 }
 
 void ClockModel::setTimezone(const QString &val)
@@ -123,7 +142,7 @@ void ClockModel::setTimezone(const QString &val)
 
 QString ClockModel::timezoneUpdates() const
 {
-    return mTimezoneUpdates;
+    return d_ptr->mTimezoneUpdates;
 }
 
 void ClockModel::setTimezoneUpdates(const QString &val)
@@ -133,7 +152,7 @@ void ClockModel::setTimezoneUpdates(const QString &val)
 
 QString ClockModel::timeUpdates() const
 {
-    return mTimeUpdates;
+    return d_ptr->mTimeUpdates;
 }
 
 void ClockModel::setTimeUpdates(const QString &val)
@@ -143,7 +162,7 @@ void ClockModel::setTimeUpdates(const QString &val)
 
 QStringList ClockModel::timeservers() const
 {
-    return mTimeservers;
+    return d_ptr->mTimeservers;
 }
 
 void ClockModel::setTimeservers(const QStringList &val)

--- a/libconnman-qt/clockmodel.h
+++ b/libconnman-qt/clockmodel.h
@@ -24,6 +24,8 @@ namespace Tests {
     class UtClock;
 }
 
+class ClockModelPrivate;
+
 class ClockModel : public QObject
 {
     Q_OBJECT
@@ -36,6 +38,7 @@ class ClockModel : public QObject
 
 public:
     ClockModel();
+    virtual ~ClockModel();
 
     QString timezone() const;
     QString timezoneUpdates() const;
@@ -64,11 +67,7 @@ private Q_SLOTS:
     void propertyChanged(const QString&, const QDBusVariant&);
 
 private:
-    NetConnmanClockInterface *mClockProxy;
-    QString mTimezone;
-    QString mTimezoneUpdates;
-    QString mTimeUpdates;
-    QStringList mTimeservers;
+    ClockModelPrivate *d_ptr;
 
     Q_DISABLE_COPY(ClockModel)
 };

--- a/libconnman-qt/clockmodel.h
+++ b/libconnman-qt/clockmodel.h
@@ -27,7 +27,6 @@ namespace Tests {
 class ClockModel : public QObject
 {
     Q_OBJECT
-
     Q_PROPERTY(QString timezone READ timezone WRITE setTimezone NOTIFY timezoneChanged)
     Q_PROPERTY(QString timezoneUpdates READ timezoneUpdates WRITE setTimezoneUpdates NOTIFY timezoneUpdatesChanged)
     Q_PROPERTY(QString timeUpdates READ timeUpdates WRITE setTimeUpdates NOTIFY timeUpdatesChanged)
@@ -38,14 +37,15 @@ class ClockModel : public QObject
 public:
     ClockModel();
 
-public Q_SLOTS:
     QString timezone() const;
-    void setTimezone(const QString &val);
     QString timezoneUpdates() const;
-    void setTimezoneUpdates(const QString &val);
     QString timeUpdates() const;
-    void setTimeUpdates(const QString &val);
     QStringList timeservers() const;
+
+public Q_SLOTS:
+    void setTimezone(const QString &val);
+    void setTimezoneUpdates(const QString &val);
+    void setTimeUpdates(const QString &val);
     void setTimeservers(const QStringList &val);
 
     void setDate(QDate date);

--- a/libconnman-qt/commondbustypes.h
+++ b/libconnman-qt/commondbustypes.h
@@ -39,12 +39,12 @@ typedef QList<ConnmanObject> ConnmanObjectList;
 Q_DECLARE_METATYPE ( ConnmanObjectList )
 
 inline void registerCommonDataTypes() {
-  qDBusRegisterMetaType<StringMap>();
-  qDBusRegisterMetaType<StringPair>();
-  qDBusRegisterMetaType<StringPairArray>();
-  qDBusRegisterMetaType<ConnmanObject>();
-  qDBusRegisterMetaType<ConnmanObjectList>();
-  qRegisterMetaType<ConnmanObjectList>("ConnmanObjectList");
+    qDBusRegisterMetaType<StringMap>();
+    qDBusRegisterMetaType<StringPair>();
+    qDBusRegisterMetaType<StringPairArray>();
+    qDBusRegisterMetaType<ConnmanObject>();
+    qDBusRegisterMetaType<ConnmanObjectList>();
+    qRegisterMetaType<ConnmanObjectList>("ConnmanObjectList");
 }
 
 #endif //COMMONDBUSTYPES_H

--- a/libconnman-qt/connmannetworkproxyfactory.h
+++ b/libconnman-qt/connmannetworkproxyfactory.h
@@ -16,6 +16,7 @@
 
 #include "networkmanager.h"
 class NetworkService;
+class ConnmanNetworkProxyFactoryPrivate;
 
 class ConnmanNetworkProxyFactory : public QObject, public QNetworkProxyFactory
 {
@@ -23,6 +24,7 @@ class ConnmanNetworkProxyFactory : public QObject, public QNetworkProxyFactory
 
 public:
     ConnmanNetworkProxyFactory(QObject *parent = 0);
+    ~ConnmanNetworkProxyFactory();
 
     // From QNetworkProxyFactory
     QList<QNetworkProxy> queryProxy(const QNetworkProxyQuery & query);
@@ -32,10 +34,7 @@ private Q_SLOTS:
     void onProxyChanged(const QVariantMap &proxy);
 
 private:
-    QPointer<NetworkService> m_defaultRoute;
-    QList<QNetworkProxy> m_cachedProxies_all;
-    QList<QNetworkProxy> m_cachedProxies_udpSocketOrTcpServerCapable;
-    QSharedPointer<NetworkManager> m_networkManager;
+    ConnmanNetworkProxyFactoryPrivate *d_ptr;
 };
 
 #endif //CONNMANNETWORKPROXYFACTORY_H

--- a/libconnman-qt/counter.cpp
+++ b/libconnman-qt/counter.cpp
@@ -15,6 +15,25 @@
 #include "counter.h"
 #include "networkmanager.h"
 
+class CounterAdaptor : public QDBusAbstractAdaptor
+{
+    Q_OBJECT
+    Q_CLASSINFO("D-Bus Interface", "net.connman.Counter")
+
+public:
+    explicit CounterAdaptor(Counter *parent);
+    virtual ~CounterAdaptor();
+
+public Q_SLOTS:
+    void Release();
+    void Usage(const QDBusObjectPath &service_path,
+                                const QVariantMap &home,
+                                const QVariantMap &roaming);
+
+private:
+    Counter *m_counter;
+};
+
 class CounterPrivate
 {
 public:
@@ -285,3 +304,4 @@ void CounterAdaptor::Usage(const QDBusObjectPath &service_path,
     }
 }
 
+#include "counter.moc"

--- a/libconnman-qt/counter.cpp
+++ b/libconnman-qt/counter.cpp
@@ -15,21 +15,50 @@
 #include "counter.h"
 #include "networkmanager.h"
 
+class CounterPrivate
+{
+public:
+    CounterPrivate();
 
-Counter::Counter(QObject *parent) :
-    QObject(parent),
-    m_manager(NetworkManager::sharedInstance()),
-    bytesInHome(0),
-    bytesOutHome(0),
-    secondsOnlineHome(0),
-    bytesInRoaming(0),
-    bytesOutRoaming(0),
-    secondsOnlineRoaming(0),
-    roamingEnabled(false),
-    currentInterval(1),
-    currentAccuracy(1024),
-    shouldBeRunning(false),
-    registered(false)
+    QSharedPointer<NetworkManager> m_manager;
+
+    quint64 bytesInHome;
+    quint64 bytesOutHome;
+    quint32 secondsOnlineHome;
+
+    quint64 bytesInRoaming;
+    quint64 bytesOutRoaming;
+    quint32 secondsOnlineRoaming;
+
+    bool roamingEnabled;
+    quint32 currentInterval;
+    quint32 currentAccuracy;
+
+    QString counterPath;
+    bool shouldBeRunning;
+
+    bool registered;
+};
+
+CounterPrivate::CounterPrivate()
+    : m_manager(NetworkManager::sharedInstance())
+    , bytesInHome(0)
+    , bytesOutHome(0)
+    , secondsOnlineHome(0)
+    , bytesInRoaming(0)
+    , bytesOutRoaming(0)
+    , secondsOnlineRoaming(0)
+    , roamingEnabled(false)
+    , currentInterval(1)
+    , currentAccuracy(1024)
+    , shouldBeRunning(false)
+    , registered(false)
+{
+}
+
+Counter::Counter(QObject *parent)
+    : QObject(parent)
+    , d_ptr(new CounterPrivate)
 {
 #if (QT_VERSION >= QT_VERSION_CHECK(5,10,0))
     quint32 randomValue = QRandomGenerator::global()->generate();
@@ -38,29 +67,33 @@ Counter::Counter(QObject *parent) :
     qsrand((uint)time.msec());
     int randomValue = qrand();
 #endif
+
     //this needs to be unique so we can use more than one at a time with different processes
-    counterPath = "/ConnectivityCounter" + QString::number(randomValue);
+    d_ptr->counterPath = "/ConnectivityCounter" + QString::number(randomValue);
 
     new CounterAdaptor(this);
-    if (!QDBusConnection::systemBus().registerObject(counterPath, this))
-        qWarning("Could not register DBus object on %s", qPrintable(counterPath));
+    if (!QDBusConnection::systemBus().registerObject(d_ptr->counterPath, this))
+        qWarning("Could not register DBus object on %s", qPrintable(d_ptr->counterPath));
 
-    connect(m_manager.data(), &NetworkManager::availabilityChanged,
+    connect(d_ptr->m_manager.data(), &NetworkManager::availabilityChanged,
             this, &Counter::updateCounterAgent);
 }
 
 Counter::~Counter()
 {
-    if (registered)
-        m_manager->unregisterCounter(counterPath);
+    if (d_ptr->registered)
+        d_ptr->m_manager->unregisterCounter(d_ptr->counterPath);
+
+    delete d_ptr;
+    d_ptr = nullptr;
 }
 
 void Counter::serviceUsage(const QString &servicePath, const QVariantMap &counters, bool roaming)
 {
     Q_EMIT counterChanged(servicePath, counters, roaming);
 
-    if (roaming != roamingEnabled) {
-        roamingEnabled = roaming;
+    if (roaming != d_ptr->roamingEnabled) {
+        d_ptr->roamingEnabled = roaming;
         Q_EMIT roamingChanged(roaming);
     }
 
@@ -70,23 +103,23 @@ void Counter::serviceUsage(const QString &servicePath, const QVariantMap &counte
 
     if (roaming) {
         if (rxbytes != 0) {
-            bytesInRoaming = rxbytes;
+            d_ptr->bytesInRoaming = rxbytes;
         }
         if (txbytes != 0) {
-            bytesOutRoaming = txbytes;
+            d_ptr->bytesOutRoaming = txbytes;
         }
         if (time != 0) {
-            secondsOnlineRoaming = time;
+            d_ptr->secondsOnlineRoaming = time;
         }
     } else {
         if (rxbytes != 0) {
-            bytesInHome = rxbytes;
+            d_ptr->bytesInHome = rxbytes;
         }
         if (txbytes != 0) {
-            bytesOutHome = txbytes;
+            d_ptr->bytesOutHome = txbytes;
         }
         if (time != 0) {
-            secondsOnlineHome = time;
+            d_ptr->secondsOnlineHome = time;
         }
     }
 
@@ -100,39 +133,39 @@ void Counter::serviceUsage(const QString &servicePath, const QVariantMap &counte
 
 void Counter::release()
 {
-    registered = false;
-    Q_EMIT runningChanged(registered);
+    d_ptr->registered = false;
+    Q_EMIT runningChanged(d_ptr->registered);
 }
 
 bool Counter::roaming() const
 {
-    return roamingEnabled;
+    return d_ptr->roamingEnabled;
 }
 
 quint64 Counter::bytesReceived() const
 {
-    if (roamingEnabled) {
-        return bytesInRoaming;
+    if (d_ptr->roamingEnabled) {
+        return d_ptr->bytesInRoaming;
     } else {
-        return bytesInHome;
+        return d_ptr->bytesInHome;
     }
 }
 
 quint64 Counter::bytesTransmitted() const
 {
-    if (roamingEnabled) {
-        return bytesOutRoaming;
+    if (d_ptr->roamingEnabled) {
+        return d_ptr->bytesOutRoaming;
     } else {
-        return bytesOutHome;
+        return d_ptr->bytesOutHome;
     }
 }
 
 quint32 Counter::secondsOnline() const
 {
-    if (roamingEnabled) {
-        return secondsOnlineRoaming;
+    if (d_ptr->roamingEnabled) {
+        return d_ptr->secondsOnlineRoaming;
     } else {
-        return secondsOnlineHome;
+        return d_ptr->secondsOnlineHome;
     }
 }
 
@@ -145,17 +178,17 @@ need to be re registered from the manager.
 */
 void Counter::setAccuracy(quint32 accuracy)
 {
-    if (currentAccuracy == accuracy)
+    if (d_ptr->currentAccuracy == accuracy)
         return;
 
-    currentAccuracy = accuracy;
+    d_ptr->currentAccuracy = accuracy;
     Q_EMIT accuracyChanged(accuracy);
     updateCounterAgent();
 }
 
 quint32 Counter::accuracy() const
 {
-    return currentAccuracy;
+    return d_ptr->currentAccuracy;
 }
 
 /*
@@ -165,59 +198,59 @@ need to be re registered from the manager.
 */
 void Counter::setInterval(quint32 interval)
 {
-    if (currentInterval == interval)
+    if (d_ptr->currentInterval == interval)
         return;
 
-    currentInterval = interval;
+    d_ptr->currentInterval = interval;
     Q_EMIT intervalChanged(interval);
     updateCounterAgent();
 }
 
 quint32 Counter::interval() const
 {
-    return currentInterval;
+    return d_ptr->currentInterval;
 }
 
 void Counter::setRunning(bool on)
 {
-    if (shouldBeRunning == on)
+    if (d_ptr->shouldBeRunning == on)
         return;
 
-    shouldBeRunning = on;
+    d_ptr->shouldBeRunning = on;
     updateCounterAgent();
 }
 
 void Counter::updateCounterAgent()
 {
-    if (!m_manager->isAvailable()) {
-        if (registered) {
-            registered = false;
-            Q_EMIT runningChanged(registered);
+    if (!d_ptr->m_manager->isAvailable()) {
+        if (d_ptr->registered) {
+            d_ptr->registered = false;
+            Q_EMIT runningChanged(d_ptr->registered);
         }
         return;
     }
 
-    if (registered) {
-        m_manager->unregisterCounter(counterPath);
-        if (!shouldBeRunning) {
-            registered = false;
-            Q_EMIT runningChanged(registered);
+    if (d_ptr->registered) {
+        d_ptr->m_manager->unregisterCounter(d_ptr->counterPath);
+        if (!d_ptr->shouldBeRunning) {
+            d_ptr->registered = false;
+            Q_EMIT runningChanged(d_ptr->registered);
             return;
         }
     }
 
-    if (shouldBeRunning) {
-        m_manager->registerCounter(counterPath, currentAccuracy, currentInterval);
-        if (!registered) {
-            registered = true;
-            Q_EMIT runningChanged(registered);
+    if (d_ptr->shouldBeRunning) {
+        d_ptr->m_manager->registerCounter(d_ptr->counterPath, d_ptr->currentAccuracy, d_ptr->currentInterval);
+        if (!d_ptr->registered) {
+            d_ptr->registered = true;
+            Q_EMIT runningChanged(d_ptr->registered);
         }
     }
 }
 
 bool Counter::running() const
 {
-    return registered;
+    return d_ptr->registered;
 }
 
 /*

--- a/libconnman-qt/counter.h
+++ b/libconnman-qt/counter.h
@@ -22,17 +22,17 @@
  */
 //  static const char counterPath[] = "/ConnectivityCounter";
 
+class CounterPrivate;
+
 class Counter : public QObject
 {
     Q_OBJECT
-
     Q_PROPERTY(quint64 bytesReceived READ bytesReceived NOTIFY bytesReceivedChanged)
     Q_PROPERTY(quint64 bytesTransmitted READ bytesTransmitted NOTIFY bytesTransmittedChanged)
     Q_PROPERTY(quint32 secondsOnline READ secondsOnline NOTIFY secondsOnlineChanged)
     Q_PROPERTY(bool roaming READ roaming NOTIFY roamingChanged)
     Q_PROPERTY(quint32 accuracy READ accuracy WRITE setAccuracy NOTIFY accuracyChanged)
     Q_PROPERTY(quint32 interval READ interval WRITE setInterval NOTIFY intervalChanged)
-
     Q_PROPERTY(bool running READ running WRITE setRunning NOTIFY runningChanged)
 
     Q_DISABLE_COPY(Counter)
@@ -70,29 +70,12 @@ private Q_SLOTS:
     void updateCounterAgent();
 
 private:
-    QSharedPointer<NetworkManager> m_manager;
+    CounterPrivate *d_ptr;
 
     friend class CounterAdaptor;
 
     void serviceUsage(const QString &servicePath, const QVariantMap &counters, bool roaming);
     void release();
-
-    quint64 bytesInHome;
-    quint64 bytesOutHome;
-    quint32 secondsOnlineHome;
-
-    quint64 bytesInRoaming;
-    quint64 bytesOutRoaming;
-    quint32 secondsOnlineRoaming;
-
-    bool roamingEnabled;
-    quint32 currentInterval;
-    quint32 currentAccuracy;
-
-    QString counterPath;
-    bool shouldBeRunning;
-
-    bool registered;
 };
 
 class CounterAdaptor : public QDBusAbstractAdaptor

--- a/libconnman-qt/counter.h
+++ b/libconnman-qt/counter.h
@@ -78,22 +78,4 @@ private:
     void release();
 };
 
-class CounterAdaptor : public QDBusAbstractAdaptor
-{
-    Q_OBJECT
-    Q_CLASSINFO("D-Bus Interface", "net.connman.Counter")
-
-public:
-    explicit CounterAdaptor(Counter *parent);
-    virtual ~CounterAdaptor();
-
-public Q_SLOTS:
-    void Release();
-    void Usage(const QDBusObjectPath &service_path,
-                                const QVariantMap &home,
-                                const QVariantMap &roaming);
-
-private:
-    Counter *m_counter;
-};
 #endif // COUNTER_H

--- a/libconnman-qt/libconnman-qt.pro
+++ b/libconnman-qt/libconnman-qt.pro
@@ -31,10 +31,6 @@ isEmpty(TARGET_SUFFIX) {
     TARGET_SUFFIX = qt$$QT_MAJOR_VERSION
 }
 
-CONFIG(debug, debug|release) {
-    DEFINES += CONNMAN_DEBUG=1
-}
-
 TARGET = $$qtLibraryTarget(connman-$$TARGET_SUFFIX)
 headers.path = $$INSTALL_ROOT$$PREFIX/include/connman-$$TARGET_SUFFIX
 
@@ -76,6 +72,7 @@ HEADERS += \
     qdbusxml2cpp_dbus_types.h
 
 SOURCES += \
+    logging.cpp \
     marshalutils.cpp \
     networkmanager.cpp \
     networktechnology.cpp \

--- a/libconnman-qt/libconnman-qt.pro
+++ b/libconnman-qt/libconnman-qt.pro
@@ -58,17 +58,17 @@ PUBLIC_HEADERS += \
     networksession.h \
     counter.h \
     vpnconnection.h \
-    vpnconnection_p.h \
     vpnmanager.h \
-    vpnmanager_p.h \
-    vpnmodel.h \
-    vpnmodel_p.h
+    vpnmodel.h
 
 HEADERS += \
     $$PUBLIC_HEADERS \
     libconnman_p.h \
     marshalutils.h \
     commondbustypes.h \
+    vpnconnection_p.h \
+    vpnmanager_p.h \
+    vpnmodel_p.h \
     qdbusxml2cpp_dbus_types.h
 
 SOURCES += \

--- a/libconnman-qt/libconnman-qt.pro
+++ b/libconnman-qt/libconnman-qt.pro
@@ -51,7 +51,6 @@ PUBLIC_HEADERS += \
     networkmanager.h \
     networktechnology.h \
     networkservice.h \
-    commondbustypes.h \
     connmannetworkproxyfactory.h \
     clockmodel.h \
     useragent.h \
@@ -69,6 +68,7 @@ HEADERS += \
     $$PUBLIC_HEADERS \
     libconnman_p.h \
     marshalutils.h \
+    commondbustypes.h \
     qdbusxml2cpp_dbus_types.h
 
 SOURCES += \

--- a/libconnman-qt/libconnman_p.h
+++ b/libconnman-qt/libconnman_p.h
@@ -12,7 +12,6 @@
 
 #include "commondbustypes.h"
 
-#define CONNMAN_BUS QDBusConnection::systemBus()
 #define CONNMAN_SERVICE QLatin1String("net.connman")
 
 class ConnmanError {

--- a/libconnman-qt/libconnman_p.h
+++ b/libconnman-qt/libconnman_p.h
@@ -11,6 +11,9 @@
 #define LIBCONNMAN_PRIVATE_H
 
 #include "commondbustypes.h"
+#include <QLoggingCategory>
+
+Q_DECLARE_LOGGING_CATEGORY(lcConnman)
 
 #define CONNMAN_SERVICE QLatin1String("net.connman")
 
@@ -53,17 +56,5 @@ public:
     static inline bool connected(QString state)
         { return (state == Online || state == Ready); }
 };
-
-#ifndef CONNMAN_DEBUG
-#  define CONNMAN_DEBUG 0
-#endif
-
-#include <QDebug>
-
-#if CONNMAN_DEBUG
-#  define DBG_(x) qDebug() << this << Q_FUNC_INFO << "line:" << __LINE__ << x
-#else
-#  define DBG_(expr) ((void)0)
-#endif
 
 #endif // LIBCONNMAN_PRIVATE_H

--- a/libconnman-qt/libconnman_p.h
+++ b/libconnman-qt/libconnman_p.h
@@ -57,21 +57,14 @@ public:
 
 #ifndef CONNMAN_DEBUG
 #  define CONNMAN_DEBUG 0
-#endif // CONNMAN_DEBUG
+#endif
 
 #include <QDebug>
 
 #if CONNMAN_DEBUG
 #  define DBG_(x) qDebug() << this << Q_FUNC_INFO << "line:" << __LINE__ << x
-#  define ASSERT_(x) ((x) ? ((void)0) : qt_assert(#x,__FILE__,__LINE__))
-#  define VERIFY_(x) ASSERT(x)
 #else
 #  define DBG_(expr) ((void)0)
-#  define ASSERT_(expr) ((void)0)
-#  define VERIFY_(x) (x)
-#endif // CONNMAN_DEBUG
-
-#define WARN_(x) qWarning() << x
-#define VERBOSE_(expr) ((void)0)
+#endif
 
 #endif // LIBCONNMAN_PRIVATE_H

--- a/libconnman-qt/logging.cpp
+++ b/libconnman-qt/logging.cpp
@@ -1,0 +1,3 @@
+#include <QLoggingCategory>
+
+Q_LOGGING_CATEGORY(lcConnman, "connman", QtWarningMsg)

--- a/libconnman-qt/marshalutils.cpp
+++ b/libconnman-qt/marshalutils.cpp
@@ -43,14 +43,23 @@ namespace {
 QVariant convertState (const QString &key, const QVariant &value, bool toDBus)
 {
     QList<QPair<QVariant, QVariant> > states;
-    states.push_back(qMakePair(QVariant::fromValue(QStringLiteral("idle")), QVariant::fromValue(static_cast<int>(VpnConnection::Idle))));
-    states.push_back(qMakePair(QVariant::fromValue(QStringLiteral("failure")), QVariant::fromValue(static_cast<int>(VpnConnection::Failure))));
-    states.push_back(qMakePair(QVariant::fromValue(QStringLiteral("association")), QVariant::fromValue(static_cast<int>(VpnConnection::Association))));
-    states.push_back(qMakePair(QVariant::fromValue(QStringLiteral("configuration")), QVariant::fromValue(static_cast<int>(VpnConnection::Configuration))));
-    states.push_back(qMakePair(QVariant::fromValue(QStringLiteral("ready")), QVariant::fromValue(static_cast<int>(VpnConnection::Ready))));
-    states.push_back(qMakePair(QVariant::fromValue(QStringLiteral("disconnect")), QVariant::fromValue(static_cast<int>(VpnConnection::Disconnect))));
+    states.push_back(qMakePair(QVariant::fromValue(QStringLiteral("idle")),
+                               QVariant::fromValue(static_cast<int>(VpnConnection::Idle))));
+    states.push_back(qMakePair(QVariant::fromValue(QStringLiteral("failure")),
+                               QVariant::fromValue(static_cast<int>(VpnConnection::Failure))));
+    states.push_back(qMakePair(QVariant::fromValue(QStringLiteral("association")),
+                               QVariant::fromValue(static_cast<int>(VpnConnection::Association))));
+    states.push_back(qMakePair(QVariant::fromValue(QStringLiteral("configuration")),
+                               QVariant::fromValue(static_cast<int>(VpnConnection::Configuration))));
+    states.push_back(qMakePair(QVariant::fromValue(QStringLiteral("ready")),
+                               QVariant::fromValue(static_cast<int>(VpnConnection::Ready))));
+    states.push_back(qMakePair(QVariant::fromValue(QStringLiteral("disconnect")),
+                               QVariant::fromValue(static_cast<int>(VpnConnection::Disconnect))));
 
-    auto lit = std::find_if(states.cbegin(), states.cend(), [value, toDBus](const QPair<QVariant, QVariant> &pair) { return value == (toDBus ? pair.second : pair.first); });
+    auto lit = std::find_if(states.cbegin(), states.cend(),
+                            [value, toDBus](const QPair<QVariant, QVariant> &pair) {
+        return value == (toDBus ? pair.second : pair.first); });
+
     if (lit != states.end()) {
         return toDBus ? (*lit).first : (*lit).second;
     }
@@ -234,7 +243,8 @@ QVariantMap MarshalUtils::propertiesToDBus(const QVariantMap &fromQml)
 
         if (key == QStringLiteral("providerProperties")) {
             const QVariantMap providerProperties(value.value<QVariantMap>());
-            for (QVariantMap::const_iterator pit = providerProperties.cbegin(), pend = providerProperties.cend(); pit != pend; ++pit) {
+            for (QVariantMap::const_iterator pit = providerProperties.cbegin(), pend = providerProperties.cend();
+                 pit != pend; ++pit) {
                 rv.insert(pit.key(), pit.value());
             }
             continue;

--- a/libconnman-qt/networkmanager.cpp
+++ b/libconnman-qt/networkmanager.cpp
@@ -379,7 +379,7 @@ class NetworkManager::InterfaceProxy: public QDBusAbstractInterface
 public:
     InterfaceProxy(NetworkManager *parent) :
         QDBusAbstractInterface(CONNMAN_SERVICE, "/", "net.connman.Manager",
-            CONNMAN_BUS, parent) {}
+            QDBusConnection::systemBus(), parent) {}
 
 public:
     QDBusPendingCall GetProperties()
@@ -440,12 +440,12 @@ NetworkManager::NetworkManager(QObject* parent)
     m_available(false)
 {
     registerCommonDataTypes();
-    QDBusServiceWatcher* watcher = new QDBusServiceWatcher(CONNMAN_SERVICE, CONNMAN_BUS,
+    QDBusServiceWatcher* watcher = new QDBusServiceWatcher(CONNMAN_SERVICE, QDBusConnection::systemBus(),
             QDBusServiceWatcher::WatchForRegistration |
             QDBusServiceWatcher::WatchForUnregistration, this);
     connect(watcher, SIGNAL(serviceRegistered(QString)), SLOT(onConnmanRegistered()));
     connect(watcher, SIGNAL(serviceUnregistered(QString)), SLOT(onConnmanUnregistered()));
-    setConnmanAvailable(CONNMAN_BUS.interface()->isServiceRegistered(CONNMAN_SERVICE));
+    setConnmanAvailable(QDBusConnection::systemBus().interface()->isServiceRegistered(CONNMAN_SERVICE));
 }
 
 NetworkManager::~NetworkManager()

--- a/libconnman-qt/networkmanager.cpp
+++ b/libconnman-qt/networkmanager.cpp
@@ -511,7 +511,7 @@ void NetworkManager::setConnmanAvailable(bool available)
                 m_priv->maybeCreateInterfaceProxyLater();
             }
         } else {
-            DBG_("connman not AVAILABLE");
+            qCDebug(lcConnman) << "connman not AVAILABLE";
             Q_EMIT availabilityChanged(m_available = false);
             disconnectFromConnman();
         }
@@ -811,7 +811,7 @@ void NetworkManager::updateServices(const ConnmanObjectList &changed, const QLis
             removedServices.append(path);
         } else {
             // connman maintains a virtual "hidden" wifi network and removes it upon init
-            DBG_("attempted to remove non-existing service" << path);
+            qCDebug(lcConnman) << "attempted to remove non-existing service" << path;
         }
     }
 
@@ -1013,7 +1013,7 @@ void NetworkManager::getPropertiesFinished(QDBusPendingCallWatcher *watcher)
     watcher->deleteLater();
 
     if (reply.isError()) {
-        DBG_(reply.error().message());
+        qCDebug(lcConnman) << reply.error().message();
         return;
     }
     QVariantMap props = reply.value();

--- a/libconnman-qt/networkmanager.cpp
+++ b/libconnman-qt/networkmanager.cpp
@@ -523,7 +523,7 @@ bool NetworkManager::connectToConnman()
     disconnectFromConnman();
     m_proxy = new InterfaceProxy(this);
     if (!m_proxy->isValid()) {
-        WARN_(m_proxy->lastError());
+        qWarning() << m_proxy->lastError();
         delete m_proxy;
         m_proxy = NULL;
         return false;
@@ -1054,7 +1054,7 @@ void NetworkManager::getServicesFinished(QDBusPendingCallWatcher *watcher)
     ConnmanObjectList services;
     watcher->deleteLater();
     if (reply.isError()) {
-        WARN_(reply.error());
+        qWarning() << reply.error();
     } else {
         services = reply.value();
     }

--- a/libconnman-qt/networkmanager.cpp
+++ b/libconnman-qt/networkmanager.cpp
@@ -404,7 +404,8 @@ public:
         { return asyncCall("CreateSession", settings, QVariant::fromValue(QDBusObjectPath(path))); }
     QDBusPendingCall DestroySession(const QString &path)
         { return asyncCall("DestroySession", QVariant::fromValue(QDBusObjectPath(path))); }
-    QDBusPendingReply<QDBusObjectPath> CreateService(const QString &type, const QString &device, const QString &network, const StringPairArray &settings)
+    QDBusPendingReply<QDBusObjectPath> CreateService(const QString &type, const QString &device,
+                                                     const QString &network, const StringPairArray &settings)
         { return asyncCall("CreateService", type, device, network, QVariant::fromValue(settings)); }
 
 Q_SIGNALS:
@@ -1350,7 +1351,8 @@ bool NetworkManager::createService(
             QDBusReply<QDBusObjectPath> reply = *watcher;
 
             if (!reply.isValid()) {
-                qWarning() << "NetworkManager: Failed to create service." << reply.error().name() << reply.error().message();
+                qWarning() << "NetworkManager: Failed to create service." << reply.error().name()
+                           << reply.error().message();
                 emit serviceCreationFailed(reply.error().name());
             } else {
                 emit serviceCreated(reply.value().path());
@@ -1375,7 +1377,8 @@ QString NetworkManager::createServiceSync(
         reply.waitForFinished();
 
         if (reply.isError()) {
-            qWarning() << "NetworkManager: Failed to create service." << reply.error().name() << reply.error().message();
+            qWarning() << "NetworkManager: Failed to create service." << reply.error().name()
+                       << reply.error().message();
         }
 
         return reply.value().path();

--- a/libconnman-qt/networkmanager.h
+++ b/libconnman-qt/networkmanager.h
@@ -10,8 +10,6 @@
 #ifndef NETWORKMANAGER_H
 #define NETWORKMANAGER_H
 
-#include "commondbustypes.h"
-
 #include "networktechnology.h"
 #include "networkservice.h"
 #include <QtDBus>
@@ -204,7 +202,6 @@ private Q_SLOTS:
     void disconnectServices();
     void setupServices();
     void propertyChanged(const QString &name, const QDBusVariant &value);
-    void updateServices(const ConnmanObjectList &changed, const QList<QDBusObjectPath> &removed);
     void technologyAdded(const QDBusObjectPath &technology, const QVariantMap &properties);
     void technologyRemoved(const QDBusObjectPath &technology);
     void getPropertiesFinished(QDBusPendingCallWatcher *watcher);

--- a/libconnman-qt/networkmanager.h
+++ b/libconnman-qt/networkmanager.h
@@ -193,39 +193,8 @@ private:
 
 private:
     class Private;
-    class InterfaceProxy;
     friend class Private;
-
-    InterfaceProxy *m_proxy;
-
-    /* Contains all property related to this net.connman.Manager object */
-    QVariantMap m_propertiesCache;
-
-    /* Not just for cache, but actual containers of Network* type objects */
-    QHash<QString, NetworkTechnology *> m_technologiesCache;
-    QHash<QString, NetworkService *> m_servicesCache;
-    bool m_servicesCacheHasUpdates;
-
-    /* Define the order of services returned in service lists */
-    QStringList m_servicesOrder;
-    QStringList m_savedServicesOrder;
-
-    /* This variable is used just to send signal if changed */
-    NetworkService* m_defaultRoute;
-
-    /* Invalid default route service for use when there is no default route */
-    NetworkService *m_invalidDefaultRoute;
-
-    /* Since VPNs are not known this holds info necessary for dropping out of VPN */
-    bool m_defaultRouteIsVPN;
-
     Private *m_priv;
-
-    static const QString State;
-    static const QString OfflineMode;
-    static const QString DefaultService;
-
-    bool m_available;
 
 private Q_SLOTS:
     void onConnmanRegistered();

--- a/libconnman-qt/networkservice.cpp
+++ b/libconnman-qt/networkservice.cpp
@@ -503,7 +503,7 @@ NetworkService::Private::Private(const QString &path, const QVariantMap &props, 
     reconnectServiceInterface();
     updateManaged();
     updateConnected();
-    DBG_(m_path << "managed:" << m_managed);
+    qCDebug(lcConnman) << m_path << "managed:" << m_managed;
 
     // Reset the signal mask (the above calls may have set some bits)
     m_queuedSignals = 0;
@@ -594,7 +594,7 @@ void NetworkService::Private::checkAccess()
 
 void NetworkService::Private::onRestrictedPropertyChanged(const QString &name)
 {
-    DBG_(name);
+    qCDebug(lcConnman) << name;
     connect(new GetPropertyWatcher(name, m_proxy),
         SIGNAL(finished(QDBusPendingCallWatcher*)),
         SLOT(onGetPropertyFinished(QDBusPendingCallWatcher*)));
@@ -609,9 +609,9 @@ void NetworkService::Private::onGetPropertyFinished(QDBusPendingCallWatcher *cal
     QDBusPendingReply<QVariant> reply = *call;
     call->deleteLater();
     if (reply.isError()) {
-        DBG_(watcher->m_name << reply.error());
+        qCDebug(lcConnman) << watcher->m_name << reply.error();
     } else {
-        DBG_(watcher->m_name << "=" << reply.value());
+        qCDebug(lcConnman) << watcher->m_name << "=" << reply.value();
         updatePropertyCache(watcher->m_name, reply.value());
         emitQueuedSignals();
     }
@@ -622,13 +622,13 @@ void NetworkService::Private::onCheckAccessFinished(QDBusPendingCallWatcher *cal
     QDBusPendingReply<uint,uint,uint> reply = *call;
     call->deleteLater();
     if (reply.isError()) {
-        DBG_(m_path << reply.error());
+        qCDebug(lcConnman) << m_path << reply.error();
     } else {
         const uint get_props = reply.argumentAt<0>();
         const uint set_props = reply.argumentAt<1>();
         const uint calls = reply.argumentAt<2>();
 
-        DBG_(get_props << set_props << calls);
+        qCDebug(lcConnman) << get_props << set_props << calls;
 
         const uint prev = m_propGetFlags;
         const bool wasManaged = managed();
@@ -645,7 +645,7 @@ void NetworkService::Private::onCheckAccessFinished(QDBusPendingCallWatcher *cal
 
         m_managed = managed();
         if (m_managed != wasManaged) {
-            DBG_(m_path << "managed:" << m_managed);
+            qCDebug(lcConnman) << m_path << "managed:" << m_managed;
             queueSignal(SignalManagedChanged);
         }
 
@@ -914,7 +914,7 @@ void NetworkService::Private::onGetPropertiesFinished(QDBusPendingCallWatcher *c
         emitQueuedSignals();
         Q_EMIT service()->propertiesReady();
     } else {
-        DBG_(m_path << reply.error());
+        qCDebug(lcConnman) << m_path << reply.error();
     }
 }
 
@@ -965,7 +965,7 @@ void NetworkService::Private::onConnectFinished(QDBusPendingCallWatcher *call)
     if (reply.isError()) {
         QDBusError error(reply.error());
         QString errorName(error.name());
-        DBG_(error);
+        qCDebug(lcConnman) << error;
 
         // InProgress means that somebody has already asked this service
         // to get connected. That's fine, we will keep watching the status.
@@ -1301,7 +1301,7 @@ void NetworkService::Private::policyCheck(const QString &rules)
         }
         da_policy_unref(policy);
     } else {
-        DBG_("Failed to parse" << rules);
+        qCDebug(lcConnman) << "Failed to parse" << rules;
     }
 }
 

--- a/libconnman-qt/networkservice.cpp
+++ b/libconnman-qt/networkservice.cpp
@@ -316,7 +316,7 @@ class NetworkService::Private::InterfaceProxy: public QDBusAbstractInterface
 public:
     InterfaceProxy(const QString &path, NetworkService::Private *parent) :
         QDBusAbstractInterface(CONNMAN_SERVICE, path, "net.connman.Service",
-            CONNMAN_BUS, parent) {}
+            QDBusConnection::systemBus(), parent) {}
 
 public Q_SLOTS:
     QDBusPendingCall GetProperties()

--- a/libconnman-qt/networksession.h
+++ b/libconnman-qt/networksession.h
@@ -20,6 +20,8 @@ namespace Tests {
 
 class SessionAgent;
 
+class NetworkSessionPrivate;
+
 class NetworkSession : public QObject
 {
     Q_OBJECT
@@ -76,10 +78,9 @@ public Q_SLOTS:
     void setPath(const QString &path);
 
 private:
-    SessionAgent *m_sessionAgent;
-    QVariantMap settingsMap;
-    QString m_path;
     void createSession();
+
+    NetworkSessionPrivate *d_ptr;
 };
 
 #endif // SESSIONSERVICE_H

--- a/libconnman-qt/networktechnology.cpp
+++ b/libconnman-qt/networktechnology.cpp
@@ -64,7 +64,7 @@ QSharedPointer<TechnologyTracker> TechnologyTracker::instance()
 
 TechnologyTracker::TechnologyTracker()
     : QObject()
-    , m_dbusWatcher(new QDBusServiceWatcher(CONNMAN_SERVICE, CONNMAN_BUS,
+    , m_dbusWatcher(new QDBusServiceWatcher(CONNMAN_SERVICE, QDBusConnection::systemBus(),
                                             QDBusServiceWatcher::WatchForRegistration
                                             | QDBusServiceWatcher::WatchForUnregistration, this))
 {
@@ -80,7 +80,7 @@ TechnologyTracker::TechnologyTracker()
     });
 
     // Monitor TechnologyAdded and TechnologyRemoved.
-    CONNMAN_BUS.connect(
+    QDBusConnection::systemBus().connect(
                 CONNMAN_SERVICE,
                 "/",
                 "net.connman.Manager",
@@ -88,7 +88,7 @@ TechnologyTracker::TechnologyTracker()
                 this,
                 SLOT(onTechnologyAdded(QDBusObjectPath,QVariantMap)));
 
-    CONNMAN_BUS.connect(
+    QDBusConnection::systemBus().connect(
                 CONNMAN_SERVICE,
                 "/",
                 "net.connman.Manager",
@@ -106,7 +106,7 @@ QSet<QString> TechnologyTracker::technologies()
 
 void TechnologyTracker::getTechnologies()
 {
-    QDBusInterface managerInterface(CONNMAN_SERVICE, "/", "net.connman.Manager", CONNMAN_BUS);
+    QDBusInterface managerInterface(CONNMAN_SERVICE, "/", "net.connman.Manager", QDBusConnection::systemBus());
 
     QDBusPendingCall pendingCall = managerInterface.asyncCall("GetTechnologies");
 
@@ -268,7 +268,7 @@ void NetworkTechnology::pendingSetProperty(const QString &key, const QVariant &v
 void NetworkTechnology::createInterface()
 {
     if (!m_path.isEmpty() && m_technologyTracker->technologies().contains(m_path)) {
-        m_technology = new NetConnmanTechnologyInterface(CONNMAN_SERVICE, m_path, CONNMAN_BUS, this);
+        m_technology = new NetConnmanTechnologyInterface(CONNMAN_SERVICE, m_path, QDBusConnection::systemBus(), this);
 
         connect(m_technology, &NetConnmanTechnologyInterface::PropertyChanged,
                 this, &NetworkTechnology::propertyChanged);

--- a/libconnman-qt/networktechnology.cpp
+++ b/libconnman-qt/networktechnology.cpp
@@ -140,13 +140,30 @@ void TechnologyTracker::onTechnologyRemoved(const QDBusObjectPath &technology)
     Q_EMIT technologyRemoved(technology.path());
 }
 
+class NetworkTechnologyPrivate
+{
+public:
+    NetworkTechnologyPrivate();
+
+    NetConnmanTechnologyInterface *m_technology;
+    QVariantMap m_propertiesCache;
+    QVariantMap m_pendingProperties;
+
+    QString m_path;
+    QSharedPointer<TechnologyTracker> m_technologyTracker;
+};
+
+NetworkTechnologyPrivate::NetworkTechnologyPrivate()
+    : m_technology(nullptr)
+{
+}
 
 NetworkTechnology::NetworkTechnology(const QString &path, const QVariantMap &properties, QObject* parent)
-  : QObject(parent)
-  , m_technology(nullptr)
+    : QObject(parent)
+    , d_ptr(new NetworkTechnologyPrivate)
 {
     Q_ASSERT(!path.isEmpty());
-    m_propertiesCache = properties;
+    d_ptr->m_propertiesCache = properties;
 
     initialize();
     setPath(path);
@@ -154,7 +171,7 @@ NetworkTechnology::NetworkTechnology(const QString &path, const QVariantMap &pro
 
 NetworkTechnology::NetworkTechnology(QObject* parent)
     : QObject(parent)
-    , m_technology(nullptr)
+    , d_ptr(new NetworkTechnologyPrivate)
 {
     initialize();
 }
@@ -166,10 +183,10 @@ NetworkTechnology::~NetworkTechnology()
 
 void NetworkTechnology::initialize()
 {
-    m_technologyTracker = TechnologyTracker::instance();
-    connect(m_technologyTracker.data(), &TechnologyTracker::technologyRemoved,
+    d_ptr->m_technologyTracker = TechnologyTracker::instance();
+    connect(d_ptr->m_technologyTracker.data(), &TechnologyTracker::technologyRemoved,
             this, &NetworkTechnology::onInterfaceChanged);
-    connect(m_technologyTracker.data(), &TechnologyTracker::technologyAdded,
+    connect(d_ptr->m_technologyTracker.data(), &TechnologyTracker::technologyAdded,
             this, &NetworkTechnology::onInterfaceChanged);
 
     createInterface();
@@ -188,62 +205,62 @@ void NetworkTechnology::getPropertiesFinished(QDBusPendingCallWatcher *call)
         // emit changes only if there are real changes.
 
         QVariantMap tmpCache = reply.value();
-        if (m_pendingProperties.contains(Powered)) {
+        if (d_ptr->m_pendingProperties.contains(Powered)) {
             bool newValue = tmpCache[Powered].toBool();
-            bool pendingValue = m_pendingProperties[Powered].toBool();
+            bool pendingValue = d_ptr->m_pendingProperties[Powered].toBool();
             setPowered(pendingValue);
             if (pendingValue == newValue) {
-                m_pendingProperties.remove(Powered);
+                d_ptr->m_pendingProperties.remove(Powered);
             }
         }
 
-        if (m_pendingProperties.contains(IdleTimeout)) {
+        if (d_ptr->m_pendingProperties.contains(IdleTimeout)) {
             quint32 newValue = tmpCache[IdleTimeout].toUInt();
-            quint32 pendingValue = m_pendingProperties[IdleTimeout].toUInt();
+            quint32 pendingValue = d_ptr->m_pendingProperties[IdleTimeout].toUInt();
             setIdleTimeout(pendingValue);
             if (pendingValue == newValue) {
-                m_pendingProperties.remove(IdleTimeout);
+                d_ptr->m_pendingProperties.remove(IdleTimeout);
             }
         }
 
-        if (m_pendingProperties.contains(Tethering)) {
+        if (d_ptr->m_pendingProperties.contains(Tethering)) {
             bool newValue = tmpCache[Tethering].toBool();
-            bool pendingValue = m_pendingProperties[Tethering].toBool();
+            bool pendingValue = d_ptr->m_pendingProperties[Tethering].toBool();
             setTethering(pendingValue);
             if (pendingValue == newValue) {
-                m_pendingProperties.remove(Tethering);
+                d_ptr->m_pendingProperties.remove(Tethering);
             }
         }
 
-        if (m_pendingProperties.contains(TetheringIdentifier)) {
+        if (d_ptr->m_pendingProperties.contains(TetheringIdentifier)) {
             QString newValue = tmpCache[TetheringIdentifier].toString();
-            QString pendingValue = m_pendingProperties[TetheringIdentifier].toString();
+            QString pendingValue = d_ptr->m_pendingProperties[TetheringIdentifier].toString();
             setTetheringId(pendingValue);
             if (pendingValue == newValue) {
-                m_pendingProperties.remove(TetheringIdentifier);
+                d_ptr->m_pendingProperties.remove(TetheringIdentifier);
             }
         }
 
-        if (m_pendingProperties.contains(TetheringPassphrase)) {
+        if (d_ptr->m_pendingProperties.contains(TetheringPassphrase)) {
             QString newValue = tmpCache[TetheringPassphrase].toString();
-            QString pendingValue = m_pendingProperties[TetheringPassphrase].toString();
+            QString pendingValue = d_ptr->m_pendingProperties[TetheringPassphrase].toString();
             setTetheringPassphrase(pendingValue);
             if (pendingValue == newValue) {
-                m_pendingProperties.remove(TetheringPassphrase);
+                d_ptr->m_pendingProperties.remove(TetheringPassphrase);
             }
         }
 
         for (const QString &name : tmpCache.keys()) {
-            if (!m_pendingProperties.contains(name)) {
-                m_propertiesCache.insert(name, tmpCache[name]);
+            if (!d_ptr->m_pendingProperties.contains(name)) {
+                d_ptr->m_propertiesCache.insert(name, tmpCache[name]);
                 emitPropertyChange(name, tmpCache[name]);
             }
         }
-        m_pendingProperties.clear();
+        d_ptr->m_pendingProperties.clear();
         Q_EMIT propertiesReady();
     } else {
         qWarning() << reply.error().message();
-        m_propertiesCache.clear();
+        d_ptr->m_propertiesCache.clear();
     }
 }
 
@@ -251,7 +268,8 @@ void NetworkTechnology::getPropertiesFinished(QDBusPendingCallWatcher *call)
 void NetworkTechnology::pendingSetProperty(const QString &key, const QVariant &value)
 {
     QDBusPendingCallWatcher *pendingCall
-            = new QDBusPendingCallWatcher(m_technology->SetProperty(key, QDBusVariant(value)), m_technology);
+            = new QDBusPendingCallWatcher(d_ptr->m_technology->SetProperty(key, QDBusVariant(value)),
+                                          d_ptr->m_technology);
     connect(pendingCall, &QDBusPendingCallWatcher::finished,
             [this, key, value](QDBusPendingCallWatcher *call) {
         QDBusPendingReply<QVariantMap> reply = *call;
@@ -260,20 +278,22 @@ void NetworkTechnology::pendingSetProperty(const QString &key, const QVariant &v
         // If technology object is not yet registered update pending value accordingly.
         // This is merely a fallback mechnanism as technologies are also istened.
         if (reply.isError() && reply.error().type() == QDBusError::UnknownObject) {
-            m_pendingProperties.insert(key, value);
+            d_ptr->m_pendingProperties.insert(key, value);
         }
     });
 }
 
 void NetworkTechnology::createInterface()
 {
-    if (!m_path.isEmpty() && m_technologyTracker->technologies().contains(m_path)) {
-        m_technology = new NetConnmanTechnologyInterface(CONNMAN_SERVICE, m_path, QDBusConnection::systemBus(), this);
+    if (!d_ptr->m_path.isEmpty() && d_ptr->m_technologyTracker->technologies().contains(d_ptr->m_path)) {
+        d_ptr->m_technology = new NetConnmanTechnologyInterface(CONNMAN_SERVICE, d_ptr->m_path,
+                                                                QDBusConnection::systemBus(), this);
 
-        connect(m_technology, &NetConnmanTechnologyInterface::PropertyChanged,
+        connect(d_ptr->m_technology, &NetConnmanTechnologyInterface::PropertyChanged,
                 this, &NetworkTechnology::propertyChanged);
 
-        QDBusPendingCallWatcher *pendingCall = new QDBusPendingCallWatcher(m_technology->GetProperties(), m_technology);
+        QDBusPendingCallWatcher *pendingCall = new QDBusPendingCallWatcher(d_ptr->m_technology->GetProperties(),
+                                                                           d_ptr->m_technology);
         connect(pendingCall, &QDBusPendingCallWatcher::finished,
                 this, &NetworkTechnology::getPropertiesFinished);
     }
@@ -281,8 +301,8 @@ void NetworkTechnology::createInterface()
 
 void NetworkTechnology::destroyInterface()
 {
-    delete m_technology;
-    m_technology = nullptr;
+    delete d_ptr->m_technology;
+    d_ptr->m_technology = nullptr;
 }
 
 // Public API
@@ -291,131 +311,131 @@ void NetworkTechnology::destroyInterface()
 
 QString NetworkTechnology::path() const
 {
-    return m_path;
+    return d_ptr->m_path;
 }
 
 QString NetworkTechnology::name() const
 {
-    return m_propertiesCache.value(Name).toString();
+    return d_ptr->m_propertiesCache.value(Name).toString();
 }
 
 QString NetworkTechnology::type() const
 {
-    return m_propertiesCache.value(Type).toString();
+    return d_ptr->m_propertiesCache.value(Type).toString();
 }
 
 bool NetworkTechnology::powered() const
 {
-    return m_propertiesCache.value(Powered).toBool();
+    return d_ptr->m_propertiesCache.value(Powered).toBool();
 }
 
 bool NetworkTechnology::connected() const
 {
-    return m_propertiesCache.value(Connected).toBool();
+    return d_ptr->m_propertiesCache.value(Connected).toBool();
 }
 
 QString NetworkTechnology::objPath() const
 {
-    if (m_technology)
-        return m_technology->path();
+    if (d_ptr->m_technology)
+        return d_ptr->m_technology->path();
     return QString();
 }
 
 quint32 NetworkTechnology::idleTimeout() const
 {
-    return m_propertiesCache.value(IdleTimeout).toUInt();
+    return d_ptr->m_propertiesCache.value(IdleTimeout).toUInt();
 }
 
 bool NetworkTechnology::tethering() const
 {
-    return m_propertiesCache.value(Tethering).toBool();
+    return d_ptr->m_propertiesCache.value(Tethering).toBool();
 }
 
 QString NetworkTechnology::tetheringId() const
 {
-    return m_propertiesCache.value(TetheringIdentifier).toString();
+    return d_ptr->m_propertiesCache.value(TetheringIdentifier).toString();
 }
 
 QString NetworkTechnology::tetheringPassphrase() const
 {
-    return m_propertiesCache.value(TetheringPassphrase).toString();
+    return d_ptr->m_propertiesCache.value(TetheringPassphrase).toString();
 }
 
 // Setters
 
 void NetworkTechnology::setPowered(bool powered)
 {
-    if (m_technology) {
+    if (d_ptr->m_technology) {
         pendingSetProperty(Powered, QVariant(powered));
     } else {
-        m_pendingProperties.insert(Powered, QVariant(powered));
+        d_ptr->m_pendingProperties.insert(Powered, QVariant(powered));
     }
 }
 
 void NetworkTechnology::setPath(const QString &path)
 {
-    if (path == m_path) {
+    if (path == d_ptr->m_path) {
         return;
     }
 
-    m_path = path;
+    d_ptr->m_path = path;
     destroyInterface();
 
-    if (!m_path.isEmpty()) {
+    if (!d_ptr->m_path.isEmpty()) {
         createInterface();
     } else {
-        QStringList keys = m_propertiesCache.keys();
-        m_propertiesCache.clear();
+        QStringList keys = d_ptr->m_propertiesCache.keys();
+        d_ptr->m_propertiesCache.clear();
         const int n = keys.count();
         for (int i=0; i<n; i++) {
             emitPropertyChange(keys.at(i), QVariant());
         }
     }
 
-    Q_EMIT pathChanged(m_path);
+    Q_EMIT pathChanged(d_ptr->m_path);
 }
 
 void NetworkTechnology::setIdleTimeout(quint32 timeout)
 {
-    if (m_technology)
+    if (d_ptr->m_technology)
         pendingSetProperty(IdleTimeout, QVariant(timeout));
     else
-        m_pendingProperties.insert(IdleTimeout, QVariant(timeout));
+        d_ptr->m_pendingProperties.insert(IdleTimeout, QVariant(timeout));
 }
 
 void NetworkTechnology::setTethering(bool b)
 {
-    if (m_technology)
+    if (d_ptr->m_technology)
         pendingSetProperty(Tethering, QVariant(b));
     else
-        m_pendingProperties.insert(Tethering, QVariant(b));
+        d_ptr->m_pendingProperties.insert(Tethering, QVariant(b));
 }
 
 void NetworkTechnology::setTetheringId(const QString &id)
 {
-    if (m_technology)
+    if (d_ptr->m_technology)
         pendingSetProperty(TetheringIdentifier, QVariant(id));
     else
-        m_pendingProperties.insert(TetheringIdentifier, QVariant(id));
+        d_ptr->m_pendingProperties.insert(TetheringIdentifier, QVariant(id));
 }
 
 void NetworkTechnology::setTetheringPassphrase(const QString &pass)
 {
-    if (m_technology)
+    if (d_ptr->m_technology)
         pendingSetProperty(TetheringPassphrase, QVariant(pass));
     else
-        m_pendingProperties.insert(TetheringPassphrase, QVariant(pass));
+        d_ptr->m_pendingProperties.insert(TetheringPassphrase, QVariant(pass));
 }
 
 // Private
 
 void NetworkTechnology::scan()
 {
-    if (!m_technology)
+    if (!d_ptr->m_technology)
         return;
 
-    QDBusPendingReply<> reply = m_technology->Scan();
-    QDBusPendingCallWatcher *watcher = new QDBusPendingCallWatcher(reply, m_technology);
+    QDBusPendingReply<> reply = d_ptr->m_technology->Scan();
+    QDBusPendingCallWatcher *watcher = new QDBusPendingCallWatcher(reply, d_ptr->m_technology);
     connect(watcher, SIGNAL(finished(QDBusPendingCallWatcher*)),
             this, SLOT(scanReply(QDBusPendingCallWatcher*)));
 }
@@ -443,7 +463,7 @@ void NetworkTechnology::emitPropertyChange(const QString &name, const QVariant &
 
 void NetworkTechnology::onInterfaceChanged(const QString &interface)
 {
-    if (interface == m_path) {
+    if (interface == d_ptr->m_path) {
         destroyInterface();
         createInterface();
     }
@@ -453,8 +473,8 @@ void NetworkTechnology::propertyChanged(const QString &name, const QDBusVariant 
 {
     QVariant tmp = value.variant();
 
-    Q_ASSERT(m_technology);
-    m_propertiesCache[name] = tmp;
+    Q_ASSERT(d_ptr->m_technology);
+    d_ptr->m_propertiesCache[name] = tmp;
     emitPropertyChange(name, tmp);
 }
 

--- a/libconnman-qt/networktechnology.h
+++ b/libconnman-qt/networktechnology.h
@@ -13,8 +13,7 @@
 #include <QtDBus>
 #include <QSharedPointer>
 
-class NetConnmanTechnologyInterface;
-class TechnologyTracker;
+class NetworkTechnologyPrivate;
 
 class NetworkTechnology : public QObject
 {
@@ -76,12 +75,7 @@ Q_SIGNALS:
     void typeChanged(const QString &type);
 
 private:
-    NetConnmanTechnologyInterface *m_technology;
-    QVariantMap m_propertiesCache;
-    QVariantMap m_pendingProperties;
-
-    QString m_path;
-    QSharedPointer<TechnologyTracker> m_technologyTracker;
+    NetworkTechnologyPrivate *d_ptr;
 
 private Q_SLOTS:
     void onInterfaceChanged(const QString &interface);

--- a/libconnman-qt/networktechnology.h
+++ b/libconnman-qt/networktechnology.h
@@ -11,8 +11,10 @@
 #define NETWORKTECHNOLOGY_H
 
 #include <QtDBus>
+#include <QSharedPointer>
 
 class NetConnmanTechnologyInterface;
+class TechnologyTracker;
 
 class NetworkTechnology : public QObject
 {
@@ -75,25 +77,22 @@ Q_SIGNALS:
 
 private:
     NetConnmanTechnologyInterface *m_technology;
-    QDBusServiceWatcher *m_dBusWatcher;
     QVariantMap m_propertiesCache;
     QVariantMap m_pendingProperties;
 
     QString m_path;
+    QSharedPointer<TechnologyTracker> m_technologyTracker;
 
 private Q_SLOTS:
+    void onInterfaceChanged(const QString &interface);
     void propertyChanged(const QString &name, const QDBusVariant &value);
     void emitPropertyChange(const QString &name, const QVariant &value);
 
     void scanReply(QDBusPendingCallWatcher *call);
     void getPropertiesFinished(QDBusPendingCallWatcher *call);
 
-    void technologyAdded(const QDBusObjectPath &technology, const QVariantMap &properties);
-    void technologyRemoved(const QDBusObjectPath &technology);
-
     void pendingSetProperty(const QString &key, const QVariant &value);
 
-    void startDBusWatching();
     void initialize();
     void createInterface();
     void destroyInterface();

--- a/libconnman-qt/sessionagent.cpp
+++ b/libconnman-qt/sessionagent.cpp
@@ -23,6 +23,22 @@ Example:
 
   */
 
+class SessionNotificationAdaptor : public QDBusAbstractAdaptor
+{
+    Q_OBJECT
+    Q_CLASSINFO("D-Bus Interface", "net.connman.Notification")
+
+public:
+    explicit SessionNotificationAdaptor(SessionAgent* parent);
+    virtual ~SessionNotificationAdaptor();
+
+public Q_SLOTS:
+    void Release();
+    void Update(const QVariantMap &settings);
+private:
+    SessionAgent* m_sessionAgent;
+};
+
 class SessionAgentPrivate
 {
 public:
@@ -160,3 +176,5 @@ void SessionNotificationAdaptor::Update(const QVariantMap &settings)
 {
     m_sessionAgent->update(settings);
 }
+
+#include "sessionagent.moc"

--- a/libconnman-qt/sessionagent.h
+++ b/libconnman-qt/sessionagent.h
@@ -47,20 +47,4 @@ private:
     friend class SessionNotificationAdaptor;
 };
 
-class SessionNotificationAdaptor : public QDBusAbstractAdaptor
-{
-    Q_OBJECT
-    Q_CLASSINFO("D-Bus Interface", "net.connman.Notification")
-
-public:
-    explicit SessionNotificationAdaptor(SessionAgent* parent);
-    virtual ~SessionNotificationAdaptor();
-
-public Q_SLOTS:
-    void Release();
-    void Update(const QVariantMap &settings);
-private:
-    SessionAgent* m_sessionAgent;
-};
-
 #endif // USERAGENT_H

--- a/libconnman-qt/sessionagent.h
+++ b/libconnman-qt/sessionagent.h
@@ -13,6 +13,7 @@
 #include "networkmanager.h"
 
 class NetConnmanSessionInterface;
+class SessionAgentPrivate;
 
 class SessionAgent : public QObject
 {
@@ -41,10 +42,7 @@ private Q_SLOTS:
     void onConnectFinished(QDBusPendingCallWatcher *watcher);
 
 private:
-    QString agentPath;
-    QVariantMap sessionSettings;
-    QSharedPointer<NetworkManager> m_manager;
-    NetConnmanSessionInterface *m_session;
+    SessionAgentPrivate *d_ptr;
 
     friend class SessionNotificationAdaptor;
 };

--- a/libconnman-qt/useragent.cpp
+++ b/libconnman-qt/useragent.cpp
@@ -12,39 +12,65 @@
 
 static const char AGENT_PATH[] = "/ConnectivityUserAgent";
 
-UserAgent::UserAgent(QObject* parent) :
-    QObject(parent),
-    m_req_data(nullptr),
-    m_manager(NetworkManager::sharedInstance()),
-    requestType(TYPE_DEFAULT),
-    agentPath(QString())
+class UserAgentPrivate
+{
+public:
+    enum ConnectionRequestType {
+        TYPE_DEFAULT =0,
+        TYPE_SUPPRESS,
+        TYPE_CLEAR
+    };
+
+    UserAgentPrivate();
+
+    ServiceRequestData *m_req_data;
+    QSharedPointer<NetworkManager> m_manager;
+    QDBusMessage currentDbusMessage;
+    ConnectionRequestType requestType;
+    QString agentPath;
+    QTimer requestTimer;
+    QDBusMessage requestMessage;
+};
+
+UserAgentPrivate::UserAgentPrivate()
+    : m_req_data(nullptr)
+    , m_manager(NetworkManager::sharedInstance())
+    , requestType(TYPE_DEFAULT)
+{
+}
+
+UserAgent::UserAgent(QObject* parent)
+    : QObject(parent)
+    , d_ptr(new UserAgentPrivate)
 {
     QString agentpath = QLatin1String("/ConnectivityUserAgent");
     setAgentPath(agentpath);
-    connect(m_manager.data(), &NetworkManager::availabilityChanged,
+    connect(d_ptr->m_manager.data(), &NetworkManager::availabilityChanged,
             this, &UserAgent::updateMgrAvailability);
 
-    requestTimer = new QTimer(this);
-    requestTimer->setSingleShot(true);
-    connect(requestTimer, &QTimer::timeout,
+    d_ptr->requestTimer.setSingleShot(true);
+    connect(&d_ptr->requestTimer, &QTimer::timeout,
             this, &UserAgent::requestTimeout);
 }
 
 UserAgent::~UserAgent()
 {
-    m_manager->unregisterAgent(QString(agentPath));
+    d_ptr->m_manager->unregisterAgent(QString(d_ptr->agentPath));
+
+    delete d_ptr;
+    d_ptr = nullptr;
 }
 
 void UserAgent::requestUserInput(ServiceRequestData* data)
 {
-    m_req_data = data;
+    d_ptr->m_req_data = data;
     Q_EMIT userInputRequested(data->objectPath, data->fields);
 }
 
 void UserAgent::cancelUserInput()
 {
-    delete m_req_data;
-    m_req_data = nullptr;
+    delete d_ptr->m_req_data;
+    d_ptr->m_req_data = nullptr;
     Q_EMIT userInputCanceled();
 }
 
@@ -55,28 +81,28 @@ void UserAgent::reportError(const QString &servicePath, const QString &error)
 
 void UserAgent::sendUserReply(const QVariantMap &input)
 {
-    if (m_req_data == nullptr) {
+    if (d_ptr->m_req_data == nullptr) {
         qWarning() << "Got reply for non-existing request";
         return;
     }
 
     if (!input.isEmpty()) {
-        QDBusMessage &reply = m_req_data->reply;
+        QDBusMessage &reply = d_ptr->m_req_data->reply;
         reply << input;
         QDBusConnection::systemBus().send(reply);
     } else {
-        QDBusMessage error = m_req_data->msg.createErrorReply(
+        QDBusMessage error = d_ptr->m_req_data->msg.createErrorReply(
             QString("net.connman.Agent.Error.Canceled"),
             QString("canceled by user"));
         QDBusConnection::systemBus().send(error);
     }
-    delete m_req_data;
-    m_req_data = nullptr;
+    delete d_ptr->m_req_data;
+    d_ptr->m_req_data = nullptr;
 }
 
 void UserAgent::requestTimeout()
 {
-    qDebug() << Q_FUNC_INFO << requestMessage.arguments();
+    qDebug() << Q_FUNC_INFO << d_ptr->requestMessage.arguments();
     setConnectionRequestType("Clear");
 }
 
@@ -84,40 +110,38 @@ void UserAgent::sendConnectReply(const QString &replyMessage, int timeout)
 {
     setConnectionRequestType(replyMessage);
 
-    if (!requestTimer->isActive())
-        requestTimer->start(timeout * 1000);
+    if (!d_ptr->requestTimer.isActive())
+        d_ptr->requestTimer.start(timeout * 1000);
 }
 
 void UserAgent::updateMgrAvailability(bool available)
 {
     if (available) {
-        m_manager->registerAgent(QString(agentPath));
+        d_ptr->m_manager->registerAgent(d_ptr->agentPath);
     } else {
-        if (requestTimer->isActive())
-            requestTimer->stop();
+        if (d_ptr->requestTimer.isActive())
+            d_ptr->requestTimer.stop();
     }
 }
 
 void UserAgent::setConnectionRequestType(const QString &type)
 {
     if (type == "Suppress") {
-        requestType = TYPE_SUPPRESS;
+        d_ptr->requestType = UserAgentPrivate::TYPE_SUPPRESS;
     } else if (type == "Clear") {
-        requestType = TYPE_CLEAR;
+        d_ptr->requestType = UserAgentPrivate::TYPE_CLEAR;
     } else {
-        requestType = TYPE_DEFAULT;
+        d_ptr->requestType = UserAgentPrivate::TYPE_DEFAULT;
     }
 }
 
 QString UserAgent::connectionRequestType() const
 {
-    switch (requestType) {
-    case TYPE_SUPPRESS:
+    switch (d_ptr->requestType) {
+    case UserAgentPrivate::TYPE_SUPPRESS:
         return "Suppress";
-        break;
-    case TYPE_CLEAR:
+    case UserAgentPrivate::TYPE_CLEAR:
         return "Clear";
-        break;
     default:
         break;
     }
@@ -128,7 +152,7 @@ void UserAgent::requestConnect(const QDBusMessage &msg)
 {
     QList<QVariant> arguments2;
     arguments2 << QVariant("Clear");
-    requestMessage = msg.createReply(arguments2);
+    d_ptr->requestMessage = msg.createReply(arguments2);
 
     QList<QVariant> arguments;
     arguments << QVariant(connectionRequestType());
@@ -149,7 +173,7 @@ void UserAgent::requestConnect(const QDBusMessage &msg)
 
 QString UserAgent::path() const
 {
-    return agentPath;
+    return d_ptr->agentPath;
 }
 
 void UserAgent::setAgentPath(const QString &path)
@@ -158,11 +182,11 @@ void UserAgent::setAgentPath(const QString &path)
         return;
 
     new AgentAdaptor(this); // this object will be freed when UserAgent is freed
-    agentPath = path;
-    QDBusConnection::systemBus().registerObject(agentPath, this);
+    d_ptr->agentPath = path;
+    QDBusConnection::systemBus().registerObject(d_ptr->agentPath, this);
 
-    if (m_manager->isAvailable()) {
-        m_manager->registerAgent(QString(agentPath));
+    if (d_ptr->m_manager->isAvailable()) {
+        d_ptr->m_manager->registerAgent(d_ptr->agentPath);
     }
 }
 

--- a/libconnman-qt/useragent.cpp
+++ b/libconnman-qt/useragent.cpp
@@ -83,12 +83,16 @@ UserAgent::~UserAgent()
 {
     d_ptr->m_manager->unregisterAgent(QString(d_ptr->agentPath));
 
+    delete d_ptr->m_req_data;
+    d_ptr->m_req_data = nullptr;
+
     delete d_ptr;
     d_ptr = nullptr;
 }
 
 void UserAgent::requestUserInput(ServiceRequestData* data)
 {
+    delete d_ptr->m_req_data;
     d_ptr->m_req_data = data;
     Q_EMIT userInputRequested(data->objectPath, data->fields);
 }
@@ -253,8 +257,8 @@ void AgentAdaptor::RequestBrowser(const QDBusObjectPath &service_path, const QSt
 }
 
 void AgentAdaptor::RequestInput(const QDBusObjectPath &service_path,
-                                       const QVariantMap &fields,
-                                       const QDBusMessage &message)
+                                const QVariantMap &fields,
+                                const QDBusMessage &message)
 {
     QVariantMap json;
     for (const QString &key : fields.keys()){

--- a/libconnman-qt/useragent.cpp
+++ b/libconnman-qt/useragent.cpp
@@ -12,6 +12,32 @@
 
 static const char AGENT_PATH[] = "/ConnectivityUserAgent";
 
+class AgentAdaptor : public QDBusAbstractAdaptor
+{
+    Q_OBJECT
+    Q_CLASSINFO("D-Bus Interface", "net.connman.Agent")
+
+public:
+    explicit AgentAdaptor(UserAgent* parent);
+    virtual ~AgentAdaptor();
+
+public Q_SLOTS:
+    void Release();
+    void ReportError(const QDBusObjectPath &service_path, const QString &error);
+    Q_NOREPLY void RequestBrowser(const QDBusObjectPath &service_path, const QString &url,
+                        const QDBusMessage &message);
+    void RequestConnect(const QDBusMessage &message);
+
+    Q_NOREPLY void RequestInput(const QDBusObjectPath &service_path,
+                                const QVariantMap &fields,
+                                const QDBusMessage &message);
+    void Cancel();
+
+private:
+    UserAgent* m_userAgent;
+    QElapsedTimer browserRequestTimer;
+};
+
 class UserAgentPrivate
 {
 public:
@@ -258,4 +284,4 @@ void AgentAdaptor::RequestConnect(const QDBusMessage &message)
     m_userAgent->requestConnect(message);
 }
 
-
+#include "useragent.moc"

--- a/libconnman-qt/useragent.h
+++ b/libconnman-qt/useragent.h
@@ -26,6 +26,8 @@ struct ServiceRequestData
     QDBusMessage msg;
 };
 
+class UserAgentPrivate;
+
 class UserAgent : public QObject
 {
     Q_OBJECT
@@ -34,12 +36,6 @@ class UserAgent : public QObject
     Q_DISABLE_COPY(UserAgent)
 
 public:
-    enum ConnectionRequestType {
-        TYPE_DEFAULT =0,
-        TYPE_SUPPRESS,
-        TYPE_CLEAR
-    };
-
     explicit UserAgent(QObject* parent = 0);
     virtual ~UserAgent();
 
@@ -74,15 +70,9 @@ private:
     void requestBrowser(const QString &servicePath, const QString &url,
                         const QDBusMessage &message);
 
-    ServiceRequestData* m_req_data;
-    QSharedPointer<NetworkManager> m_manager;
-    QDBusMessage currentDbusMessage;
-    ConnectionRequestType requestType;
-    QString agentPath;
+    UserAgentPrivate *d_ptr;
 
     friend class AgentAdaptor;
-    QTimer *requestTimer;
-    QDBusMessage requestMessage;
 };
 
 class AgentAdaptor : public QDBusAbstractAdaptor

--- a/libconnman-qt/useragent.h
+++ b/libconnman-qt/useragent.h
@@ -75,30 +75,4 @@ private:
     friend class AgentAdaptor;
 };
 
-class AgentAdaptor : public QDBusAbstractAdaptor
-{
-    Q_OBJECT
-    Q_CLASSINFO("D-Bus Interface", "net.connman.Agent")
-
-public:
-    explicit AgentAdaptor(UserAgent* parent);
-    virtual ~AgentAdaptor();
-
-public Q_SLOTS:
-    void Release();
-    void ReportError(const QDBusObjectPath &service_path, const QString &error);
-    Q_NOREPLY void RequestBrowser(const QDBusObjectPath &service_path, const QString &url,
-                        const QDBusMessage &message);
-    void RequestConnect(const QDBusMessage &message);
-
-    Q_NOREPLY void RequestInput(const QDBusObjectPath &service_path,
-                                const QVariantMap &fields,
-                                const QDBusMessage &message);
-    void Cancel();
-
-private:
-    UserAgent* m_userAgent;
-    QElapsedTimer browserRequestTimer;
-};
-
 #endif // USERAGENT_H

--- a/libconnman-qt/useragent.h
+++ b/libconnman-qt/useragent.h
@@ -34,23 +34,23 @@ class UserAgent : public QObject
     Q_DISABLE_COPY(UserAgent)
 
 public:
-    explicit UserAgent(QObject* parent = 0);
-    virtual ~UserAgent();
-
     enum ConnectionRequestType {
         TYPE_DEFAULT =0,
         TYPE_SUPPRESS,
         TYPE_CLEAR
     };
 
+    explicit UserAgent(QObject* parent = 0);
+    virtual ~UserAgent();
+
+    QString connectionRequestType() const;
+    QString path() const;
+
 public Q_SLOTS:
     void sendUserReply(const QVariantMap &input);
 
     void sendConnectReply(const QString &replyMessage, int timeout = 120);
     void setConnectionRequestType(const QString &type);
-    QString connectionRequestType() const;
-
-    QString path() const;
     void setAgentPath(const QString &path);
 
 Q_SIGNALS:

--- a/plugin/plugin.cpp
+++ b/plugin/plugin.cpp
@@ -17,7 +17,7 @@
 #include <networkservice.h>
 #include <clockmodel.h>
 #include "declarativenetworkmanager.h"
-#include "technologymodel.h"
+#include "technologyservicemodel.h"
 #include "savedservicemodel.h"
 #include "useragent.h"
 #include "networksession.h"
@@ -51,6 +51,7 @@ void ConnmanPlugin::registerTypes(const char *uri)
     }
 
     qmlRegisterType<NetworkService>(uri, 0, 2, "NetworkService");
+    qmlRegisterType<TechnologyServiceModel>(uri, 0, 2, "TechnologyServiceModel");
     qmlRegisterType<TechnologyModel>(uri, 0, 2, "TechnologyModel");
     qmlRegisterType<SavedServiceModel>(uri, 0, 2, "SavedServiceModel");
     qmlRegisterType<UserAgent>(uri, 0, 2, "UserAgent");

--- a/plugin/plugin.pro
+++ b/plugin/plugin.pro
@@ -5,12 +5,12 @@ CONFIG += plugin
 
 SOURCES = \
     plugin.cpp \
-    technologymodel.cpp \
+    technologyservicemodel.cpp \
     savedservicemodel.cpp \
     declarativenetworkmanager.cpp
 
 HEADERS = \
-    technologymodel.h \
+    technologyservicemodel.h \
     savedservicemodel.h \
     declarativenetworkmanager.h
 

--- a/plugin/technologyservicemodel.h
+++ b/plugin/technologyservicemodel.h
@@ -17,13 +17,11 @@
 #include <networkservice.h>
 
 /*
- * TechnologyModel is a list model specific to a certain technology (wifi by default).
+ * TechnologyServiceModel is a list model specific to a certain technology (wifi by default).
  */
-class TechnologyModel : public QAbstractListModel
+class TechnologyServiceModel : public QAbstractListModel
 {
     Q_OBJECT
-    Q_DISABLE_COPY(TechnologyModel)
-
     Q_PROPERTY(QString name READ name WRITE setName NOTIFY nameChanged)
     Q_PROPERTY(bool available READ isAvailable NOTIFY availabilityChanged)
     Q_PROPERTY(bool connected READ isConnected NOTIFY connectedChanged)
@@ -45,8 +43,8 @@ public:
         ServiceRole = Qt::UserRole + 1
     };
 
-    TechnologyModel(QAbstractListModel* parent = 0);
-    virtual ~TechnologyModel();
+    TechnologyServiceModel(QObject *parent = 0);
+    virtual ~TechnologyServiceModel();
 
     QVariant data(const QModelIndex &index, int role) const;
     int rowCount(const QModelIndex &parent = QModelIndex()) const;
@@ -82,6 +80,8 @@ Q_SIGNALS:
     void scanRequestFinished();
 
 private:
+    Q_DISABLE_COPY(TechnologyServiceModel)
+
     QString m_techname;
     QSharedPointer<NetworkManager> m_manager;
     NetworkTechnology* m_tech;
@@ -102,6 +102,12 @@ private Q_SLOTS:
     void changedConnected(bool);
     void finishedScan();
     void networkServiceDestroyed(QObject *);
+};
+
+class TechnologyModel: public TechnologyServiceModel
+{
+public:
+    TechnologyModel(QObject *parent = 0);
 };
 
 #endif // TECHNOLOGYMODEL_H


### PR DESCRIPTION
Various changes here. Individual commits can help following what's happening.

Including here:
- Shared technology tracker in networktechnology.cpp instead of each instance following d-bus and adjusting a global set.
- Qml technologymodel renamed as technologyservicemodel as that's what the model side is doing, it's not a model of technologies. Old name still provided for backward compatibility.
-  Finished the partly done pimplification.
- Avoid custom logging.
- Avoid installing private headers.