### PR TITLE
[libconnman-qt] Remove unnecessary warnings. JB#61909

### DIFF
--- a/plugin/technologyservicemodel.cpp
+++ b/plugin/technologyservicemodel.cpp
@@ -79,7 +79,6 @@ bool TechnologyServiceModel::isConnected() const
     if (m_tech) {
         return m_tech->connected();
     } else {
-        qWarning() << "Can't get: technology is NULL";
         return false;
     }
 }
@@ -89,7 +88,6 @@ bool TechnologyServiceModel::isPowered() const
     if (m_tech) {
         return m_tech->powered();
     } else {
-        qWarning() << "Can't get: technology is NULL";
         return false;
     }
 }


### PR DESCRIPTION
Minor drive-by cleanup while testing the new enums:

When using the model in qml and having bindings involving values of powered or connected properties, these were guaranteed to create a bunch of warnings while loading.

These should be safe to ignore.