### PR TITLE
[connman-qt5] Ensure d-bus datatypes registered also in NetworkTechnology. JB#62428

### DIFF
--- a/libconnman-qt/commondbustypes.cpp
+++ b/libconnman-qt/commondbustypes.cpp
@@ -27,3 +27,17 @@ const QDBusArgument &operator>>(const QDBusArgument &argument, ConnmanObject &ob
     argument.endStructure();
     return argument;
 }
+
+void registerCommonDataTypes()
+{
+    static bool initialized = false;
+    if (!initialized) {
+        initialized = true;
+        qDBusRegisterMetaType<StringMap>();
+        qDBusRegisterMetaType<StringPair>();
+        qDBusRegisterMetaType<StringPairArray>();
+        qDBusRegisterMetaType<ConnmanObject>();
+        qDBusRegisterMetaType<ConnmanObjectList>();
+        qRegisterMetaType<ConnmanObjectList>("ConnmanObjectList");
+    }
+}

--- a/libconnman-qt/commondbustypes.h
+++ b/libconnman-qt/commondbustypes.h
@@ -38,14 +38,7 @@ const QDBusArgument &operator>>(const QDBusArgument &argument, ConnmanObject &ob
 typedef QList<ConnmanObject> ConnmanObjectList;
 Q_DECLARE_METATYPE ( ConnmanObjectList )
 
-inline void registerCommonDataTypes() {
-    qDBusRegisterMetaType<StringMap>();
-    qDBusRegisterMetaType<StringPair>();
-    qDBusRegisterMetaType<StringPairArray>();
-    qDBusRegisterMetaType<ConnmanObject>();
-    qDBusRegisterMetaType<ConnmanObjectList>();
-    qRegisterMetaType<ConnmanObjectList>("ConnmanObjectList");
-}
+void registerCommonDataTypes();
 
 #define CONNMAN_SERVICE QLatin1String("net.connman")
 

--- a/libconnman-qt/networktechnology.cpp
+++ b/libconnman-qt/networktechnology.cpp
@@ -69,6 +69,8 @@ TechnologyTracker::TechnologyTracker()
                                             QDBusServiceWatcher::WatchForRegistration
                                             | QDBusServiceWatcher::WatchForUnregistration, this))
 {
+    registerCommonDataTypes();
+
     // Monitor connman itself.
     connect(m_dbusWatcher, &QDBusServiceWatcher::serviceRegistered,
             this, &TechnologyTracker::getTechnologies);


### PR DESCRIPTION
By using just NetworkTechnology, it seemed possible to get the app aborting due to
QDBusPendingReply: type ConnmanObjectList is not registered with QtDBus