### PR TITLE
[libconnman-qt] Drop VPN Connect and Disconnect use. JB#62635

### DIFF
--- a/libconnman-qt/connman_vpn_connection.xml
+++ b/libconnman-qt/connman_vpn_connection.xml
@@ -13,11 +13,6 @@
     <method name="ClearProperty">
       <arg name="name" type="s" direction="in"/>
     </method>
-    <method name="Connect"/>
-    <method name="Connect2">
-      <arg name="dbus_sender" type="s" direction="in"/>
-    </method>
-    <method name="Disconnect"/>
     <signal name="PropertyChanged">
       <arg name="name" type="s"/>
       <arg name="value" type="v"/>

--- a/libconnman-qt/vpnconnection.cpp
+++ b/libconnman-qt/vpnconnection.cpp
@@ -162,40 +162,6 @@ void VpnConnection::modifyConnection(const QVariantMap &properties)
         QDBusVariant(MarshalUtils::propertiesToDBus(updatedProperties)));
 }
 
-void VpnConnection::activate()
-{
-    Q_D(VpnConnection);
-
-    QDBusPendingCall call = d->m_connectionProxy.Connect();
-    qDebug() << "Connect to vpn" << d->m_path;
-
-    QDBusPendingCallWatcher *watcher = new QDBusPendingCallWatcher(call, this);
-    connect(watcher, &QDBusPendingCallWatcher::finished, this, [d](QDBusPendingCallWatcher *watcher) {
-        QDBusPendingReply<void> reply = *watcher;
-        watcher->deleteLater();
-
-        if (reply.isError()) {
-            qDebug() << "Unable to activate Connman VPN connection:" << d->m_path << ":" << reply.error().message();
-        }
-    });
-}
-
-void VpnConnection::deactivate()
-{
-    Q_D(VpnConnection);
-
-    QDBusPendingCall call = d->m_connectionProxy.Disconnect();
-
-    QDBusPendingCallWatcher *watcher = new QDBusPendingCallWatcher(call, this);
-    connect(watcher, &QDBusPendingCallWatcher::finished, this, [d](QDBusPendingCallWatcher *watcher) {
-        QDBusPendingReply<void> reply = *watcher;
-        watcher->deleteLater();
-        if (reply.isError()) {
-            qDebug() << "Unable to deactivate Connman VPN connection:" << d->m_path << ":" << reply.error().message();
-        }
-    });
-}
-
 void VpnConnection::update(const QVariantMap &updateProperties)
 {
     Q_D(VpnConnection);

--- a/libconnman-qt/vpnconnection.h
+++ b/libconnman-qt/vpnconnection.h
@@ -94,8 +94,6 @@ public:
     virtual ~VpnConnection();
 
     void modifyConnection(const QVariantMap &properties);
-    void activate();
-    void deactivate();
     void update(const QVariantMap &updateProperties);
     int connected() const;
 

--- a/libconnman-qt/vpnmanager.cpp
+++ b/libconnman-qt/vpnmanager.cpp
@@ -247,7 +247,6 @@ void VpnManager::deleteConnection(const QString &path)
                 disconnect(conn, &VpnConnection::stateChanged, this, nullptr);
                 VpnManager::deleteConnection(path);
             });
-            conn->deactivate();
         } else {
             QDBusPendingCall call = d->m_connmanVpn.Remove(QDBusObjectPath(path));
             QDBusPendingCallWatcher *watcher = new QDBusPendingCallWatcher(call, this);
@@ -264,41 +263,6 @@ void VpnManager::deleteConnection(const QString &path)
         }
     } else {
         qDebug() << "Unable to delete unknown connection:" << path;
-    }
-}
-
-void VpnManager::activateConnection(const QString &path)
-{
-    Q_D(VpnManager);
-
-    qDebug() << "Connect" << path;
-    for (VpnConnection *conn : d->m_items) {
-        QString otherPath = conn->path();
-        if (otherPath != path && (conn->state() == VpnConnection::Ready ||
-                                conn->state() == VpnConnection::Configuration ||
-                                conn->state() == VpnConnection::Association)) {
-            deactivateConnection(otherPath);
-            qDebug() << "Adding pending vpn disconnect" << otherPath << conn->state() << "when connecting to vpn";
-        }
-    }
-
-    qDebug() << "About to connect path:" << path;
-    VpnConnection *conn = connection(path);
-    if (conn) {
-        conn->activate();
-    } else {
-        qDebug() << "Can't find VPN connection to activate it:" << path;
-    }
-}
-
-void VpnManager::deactivateConnection(const QString &path)
-{
-    qDebug() << "Disconnect" << path;
-    VpnConnection *conn = connection(path);
-    if (conn) {
-        conn->deactivate();
-    } else {
-        qDebug() << "Can't find VPN connection to deactivate it:" << path;
     }
 }
 

--- a/libconnman-qt/vpnmanager.h
+++ b/libconnman-qt/vpnmanager.h
@@ -78,9 +78,6 @@ public:
     Q_INVOKABLE void modifyConnection(const QString &path, const QVariantMap &properties);
     Q_INVOKABLE void deleteConnection(const QString &path);
 
-    Q_INVOKABLE void activateConnection(const QString &path);
-    Q_INVOKABLE void deactivateConnection(const QString &path);
-
     Q_INVOKABLE VpnConnection *connection(const QString &path) const;
     Q_INVOKABLE VpnConnection *get(int index) const;
     Q_INVOKABLE int indexOf(const QString &path) const;

--- a/plugin/plugins.qmltypes
+++ b/plugin/plugins.qmltypes
@@ -955,14 +955,6 @@ Module {
             Parameter { name: "path"; type: "string" }
         }
         Method {
-            name: "activateConnection"
-            Parameter { name: "path"; type: "string" }
-        }
-        Method {
-            name: "deactivateConnection"
-            Parameter { name: "path"; type: "string" }
-        }
-        Method {
             name: "connection"
             type: "VpnConnection*"
             Parameter { name: "path"; type: "string" }


### PR DESCRIPTION
These should go over net.connman.Service but since the autoconnect value is already used to control the connections it is enough and other use can be dropped.