### PR TITLE
Add tethering client list support

### DIFF
--- a/libconnman-qt/marshalutils.h
+++ b/libconnman-qt/marshalutils.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2016 - 2019 Jolla Ltd.
  * Copyright (c) 2019 Open Mobile Platform LLC.
+ * Copyright (c) 2025 Jolla Mobile Ltd
  *
  * You may use this file under the terms of the BSD license as follows:
  *
@@ -59,6 +60,7 @@ namespace MarshalUtils
     QVariant convertToQml(const QString &key, const QVariant &value);
     QVariant convertToDBus(const QString &key, const QVariant &value);
     QVariantMap propertiesToDBus(const QVariantMap &fromQml);
+    QVariantList parseTetheringClientsToList(const QVariantMap &fromDBus);
 }
 
 #endif // MARSHALUTILS_H

--- a/libconnman-qt/networkmanager.h
+++ b/libconnman-qt/networkmanager.h
@@ -1,6 +1,7 @@
 /*
  * Copyright © 2010 Intel Corporation.
  * Copyright © 2012-2020 Jolla Ltd.
+ * Copyright © 2025 Jolla Mobile Ltd
  *
  * This program is licensed under the terms and conditions of the
  * Apache License, version 2.0. The full text of the Apache License
@@ -57,6 +58,8 @@ class NetworkManager : public QObject
     Q_PROPERTY(QString BluetoothTechnology READ bluetoothTechnologyPath CONSTANT)
     Q_PROPERTY(QString GpsTechnology READ gpsTechnologyPath CONSTANT)
     Q_PROPERTY(QString EthernetTechnology READ ethernetTechnologyPath CONSTANT)
+
+    Q_PROPERTY(QVariantList tetheringClients READ getTetheringClients NOTIFY tetheringClientsChanged)
 
 public:
     enum State {
@@ -136,6 +139,8 @@ public:
     QString gpsTechnologyPath() const;
     QString ethernetTechnologyPath() const;
 
+    QVariantList getTetheringClients() const;
+
 public Q_SLOTS:
     void setOfflineMode(bool offlineMode);
     void registerAgent(const QString &path);
@@ -177,6 +182,9 @@ Q_SIGNALS:
     void servicesListChanged(const QStringList &list);
     void serviceAdded(const QString &servicePath);
     void serviceRemoved(const QString &servicePath);
+    void tetheringClientsChanged();
+    void tetheringClientAdded(const QString &macAddress);
+    void tetheringClientRemoved(const QString &macAddress);
 
     void serviceCreated(const QString &servicePath);
     void serviceCreationFailed(const QString &error);
@@ -201,6 +209,7 @@ private:
     QStringList selectServiceList(const QStringList &list, const QString &tech) const;
     QStringList selectServiceList(const QStringList &list, ServiceSelector selector) const;
     void updateDefaultRoute();
+    void updateTetheringClients();
 
 private:
     class Private;
@@ -215,11 +224,13 @@ private Q_SLOTS:
     void disconnectServices();
     void setupServices();
     void propertyChanged(const QString &name, const QDBusVariant &value);
+    void handleTetheringClientsChanged(const QStringList &added, const QStringList &removed);
     void technologyAdded(const QDBusObjectPath &technology, const QVariantMap &properties);
     void technologyRemoved(const QDBusObjectPath &technology);
     void getPropertiesFinished(QDBusPendingCallWatcher *watcher);
     void getTechnologiesFinished(QDBusPendingCallWatcher *watcher);
     void getServicesFinished(QDBusPendingCallWatcher *watcher);
+    void getTetheringClientsDetailsFinished(QDBusPendingCallWatcher *watcher);
 
 private:
     Q_DISABLE_COPY(NetworkManager)

--- a/libconnman-qt/networktechnology.cpp
+++ b/libconnman-qt/networktechnology.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright © 2010 Intel Corporation.
  * Copyright © 2012-2017 Jolla Ltd.
- * Contact: Slava Monich <slava.monich@jolla.com>
+ * Copyright © 2025 Jolla Mobile Ltd
  *
  * This program is licensed under the terms and conditions of the
  * Apache License, version 2.0. The full text of the Apache License

--- a/plugin/declarativenetworkmanager.cpp
+++ b/plugin/declarativenetworkmanager.cpp
@@ -1,3 +1,11 @@
+/*
+ * Copyright © 2025 Jolla Mobile Ltd
+ *
+ * This program is licensed under the terms and conditions of the
+ * Apache License, version 2.0.  The full text of the Apache License is at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
 #include "declarativenetworkmanager.h"
 
 #include <QDebug>
@@ -76,6 +84,12 @@ DeclarativeNetworkManager::DeclarativeNetworkManager(QObject *parent)
             this, &DeclarativeNetworkManager::serviceCreated);
     connect(m_sharedInstance.data(), &NetworkManager::serviceCreationFailed,
             this, &DeclarativeNetworkManager::serviceCreationFailed);
+    connect(m_sharedInstance.data(), &NetworkManager::tetheringClientsChanged,
+            this, &DeclarativeNetworkManager::tetheringClientsChanged);
+    connect(m_sharedInstance.data(), &NetworkManager::tetheringClientAdded,
+            this, &DeclarativeNetworkManager::tetheringClientAdded);
+    connect(m_sharedInstance.data(), &NetworkManager::tetheringClientRemoved,
+            this, &DeclarativeNetworkManager::tetheringClientRemoved);
 }
 
 DeclarativeNetworkManager::~DeclarativeNetworkManager()
@@ -267,6 +281,11 @@ void DeclarativeNetworkManager::registerCounter(const QString &path, quint32 acc
 void DeclarativeNetworkManager::unregisterCounter(const QString &path)
 {
     m_sharedInstance->unregisterCounter(path);
+}
+
+QVariantList DeclarativeNetworkManager::getTetheringClients() const
+{
+    return m_sharedInstance->getTetheringClients();
 }
 
 bool DeclarativeNetworkManager::createService(

--- a/plugin/declarativenetworkmanager.h
+++ b/plugin/declarativenetworkmanager.h
@@ -1,3 +1,11 @@
+/*
+ * Copyright © 2025 Jolla Mobile Ltd
+ *
+ * This program is licensed under the terms and conditions of the
+ * Apache License, version 2.0.  The full text of the Apache License is at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
 #ifndef DECLARATIVENETWORKMANAGER_H
 #define DECLARATIVENETWORKMANAGER_H
 
@@ -49,6 +57,8 @@ class DeclarativeNetworkManager: public QObject
     Q_PROPERTY(QString GpsTechnology READ gpsTechnologyPath CONSTANT)
     Q_PROPERTY(QString EthernetTechnology READ ethernetTechnologyPath CONSTANT)
 
+    Q_PROPERTY(QVariantList tetheringClients READ getTetheringClients NOTIFY tetheringClientsChanged)
+
 public:
     // needs to match NetworkManager's enum
     enum State {
@@ -89,6 +99,8 @@ public:
     QString bluetoothTechnologyPath() const;
     QString gpsTechnologyPath() const;
     QString ethernetTechnologyPath() const;
+
+    QVariantList getTetheringClients() const;
 
     Q_INVOKABLE QStringList servicesList(const QString &tech);
     Q_INVOKABLE QStringList savedServicesList(const QString &tech = QString());
@@ -156,6 +168,10 @@ Q_SIGNALS:
     void serviceRemoved(const QString &servicePath);
     void serviceCreated(const QString &servicePath);
     void serviceCreationFailed(const QString &error);
+
+    void tetheringClientsChanged();
+    void tetheringClientAdded(const QString &macAddress);
+    void tetheringClientRemoved(const QString &macAddress);
 
 private:
     QSharedPointer<NetworkManager> m_sharedInstance;

--- a/plugin/plugins.qmltypes
+++ b/plugin/plugins.qmltypes
@@ -145,6 +145,7 @@ Module {
         Property { name: "BluetoothTechnology"; type: "string"; isReadonly: true }
         Property { name: "GpsTechnology"; type: "string"; isReadonly: true }
         Property { name: "EthernetTechnology"; type: "string"; isReadonly: true }
+        Property { name: "tetheringClients"; type: "QVariantList"; isReadonly: true }
         Signal { name: "availabilityChanged" }
         // sdk-make-qmltypes:keep
         Signal { name: "inputRequestTimeoutChanged" }
@@ -171,6 +172,15 @@ Module {
         Signal {
             name: "serviceCreationFailed"
             Parameter { name: "error"; type: "string" }
+        }
+        Signal { name: "tetheringClientsChanged" }
+        Signal {
+            name: "tetheringClientAdded"
+            Parameter { name: "macAddress"; type: "string" }
+        }
+        Signal {
+            name: "tetheringClientRemoved"
+            Parameter { name: "macAddress"; type: "string" }
         }
         // sdk-make-qmltypes:keep
         Signal { name: "serviceEnabledChanged" }
@@ -286,6 +296,9 @@ Module {
             name: "resetCountersForType"
             Parameter { name: "type"; type: "string" }
         }
+        Method {
+            name: "getTetheringClients"
+            type: "QVariantList"
     }
     Component {
         name: "DeclarativeNetworkManagerFactory"


### PR DESCRIPTION
Add listening of the signal and notify new and disconnected clients up. Notify that the list is changed so it can be requested to be updated by the UI. Clear the list when tethering goes off.