### PR TITLE
Add support for mDNS

### DIFF
--- a/libconnman-qt/networkservice.cpp
+++ b/libconnman-qt/networkservice.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright © 2010 Intel Corporation.
  * Copyright © 2012-2019 Jolla Ltd.
- * Contact: Slava Monich <slava.monich@jolla.com>
+ * Copyright © 2025 Jolla Mobile Ltd
  *
  * This program is licensed under the terms and conditions of the
  * Apache License, version 2.0. The full text of the Apache License
@@ -80,7 +80,9 @@ static QString ConnmanErrorInProgress = QStringLiteral("net.connman.Error.InProg
     ConnmanArg("AnonymousIdentity",AnonymousIdentity,anonymousIdentity) \
     ConnmanNoArg("Available",Available,available) \
     ConnmanNoArg("Saved",Saved,saved) \
-    ClassNoArg(Valid,valid)
+    ClassNoArg(Valid,valid) \
+    ConnmanArg("mDNS", MDNS, mDNS) \
+    ConnmanArg("mDNS.Configuration", MDNSConfiguration, mDNSConfiguration)
 
 #define NETWORK_SERVICE_PROPERTIES2(Connman,Class) \
     NETWORK_SERVICE_PROPERTIES(Connman,Connman,Class,Class)
@@ -1140,6 +1142,12 @@ void NetworkService::Private::resetProperties()
         } else if (key == AnonymousIdentity) {
             queueSignal(SignalAnonymousIdentityChanged);
             setPropertyAvailable(&PropAnonymousIdentity, false);
+        } else if (key == MDNS) {
+            if (value.toBool())
+                queueSignal(SignalMDNSChanged);
+        } else if (key == MDNSConfiguration) {
+            if (value.toBool())
+                queueSignal(SignalMDNSConfigurationChanged);
         }
     }
     updateManaged();
@@ -1259,6 +1267,10 @@ void NetworkService::Private::updatePropertyCache(const QString &name, const QVa
     } else if (name == AnonymousIdentity) {
         queueSignal(SignalAnonymousIdentityChanged);
         setPropertyAvailable(&PropAnonymousIdentity, true);
+    } else if (name == MDNS) {
+        queueSignal(SignalMDNSChanged);
+    } else if (name == MDNSConfiguration) {
+    	queueSignal(SignalMDNSConfigurationChanged);
     }
 
     updateManaged();
@@ -1850,6 +1862,24 @@ QString NetworkService::anonymousIdentity() const
 void NetworkService::setAnonymousIdentity(const QString &anonymousIdentity)
 {
     m_priv->setProperty(Private::AnonymousIdentity, anonymousIdentity);
+}
+
+bool NetworkService::mDNS() const
+{
+    return m_priv->boolValue(Private::MDNS);
+}
+
+bool NetworkService::mDNSConfiguration() const
+{
+    return m_priv->boolValue(Private::MDNSConfiguration);
+}
+
+void NetworkService::setmDNSConfiguration(bool mDNSConfiguration)
+{
+    Private::InterfaceProxy *service = m_priv->m_proxy;
+    if (service) {
+        service->SetProperty(Private::MDNSConfiguration, mDNSConfiguration);
+    }
 }
 
 #include "networkservice.moc"

--- a/libconnman-qt/networkservice.h
+++ b/libconnman-qt/networkservice.h
@@ -1,7 +1,7 @@
 /*
  * Copyright © 2010 Intel Corporation.
  * Copyright © 2012-2019 Jolla Ltd.
- * Contact: Slava Monich <slava.monich@jolla.com>
+ * Copyright © 2025 Jolla Mobile Ltd
  *
  * This program is licensed under the terms and conditions of the
  * Apache License, version 2.0. The full text of the Apache License
@@ -85,6 +85,8 @@ class NetworkService : public QObject
     Q_PROPERTY(QString domainSuffixMatch READ domainSuffixMatch WRITE setDomainSuffixMatch NOTIFY domainSuffixMatchChanged)
     Q_PROPERTY(QString phase2 READ phase2 WRITE setPhase2 NOTIFY phase2Changed)
     Q_PROPERTY(QString anonymousIdentity READ anonymousIdentity WRITE setAnonymousIdentity NOTIFY anonymousIdentityChanged)
+    Q_PROPERTY(bool mDNS READ mDNS NOTIFY mDNSChanged)
+    Q_PROPERTY(bool mDNSConfiguration READ mDNSConfiguration WRITE setmDNSConfiguration NOTIFY mDNSConfigurationChanged)
 
     class Private;
     friend class Private;
@@ -151,6 +153,8 @@ public:
     QString domainSuffixMatch() const;
     QString phase2() const;
     QString anonymousIdentity() const;
+    bool mDNS() const;
+    bool mDNSConfiguration() const;
 
     void setPath(const QString &path);
     void updateProperties(const QVariantMap &properties);
@@ -245,6 +249,8 @@ Q_SIGNALS:
     void roamingChanged(bool roaming);
     void timeserversChanged(const QStringList &timeservers);
     void timeserversConfigChanged(const QStringList &timeservers);
+    void mDNSChanged(bool mDNS);
+    void mDNSConfigurationChanged(bool mDNSConfiguration);
 
     void serviceConnectionStarted();
     void serviceDisconnectionStarted();
@@ -298,6 +304,7 @@ public Q_SLOTS:
     void setDomainSuffixMatch(const QString &domainSuffixMatch);
     void setPhase2(const QString &phase2);
     void setAnonymousIdentity(const QString &anonymousIdentity);
+    void setmDNSConfiguration(bool mDNSConfiguration);
 
     void resetCounters();
 


### PR DESCRIPTION
The value "mDNS" is the real value that is set, and loaded for the service. This is signaled always when the value changes. The "mDNS.Configuration" is the requested configuration value for mDNS set via D-Bus. This is not always communicated upwards when "mDNS" changes, but the "mDNS" value is changed based on changes made with "mDNS.Configuration", and "mDNS" is not read from D-Bus SetProperty() call content. Thus, "mDNS" is the effective value and setting happens with "mDNS.Configuration".