### PR TITLE
Add WiFi WPA3 support level property

### DIFF
--- a/libconnman-qt/networkmanager.cpp
+++ b/libconnman-qt/networkmanager.cpp
@@ -27,6 +27,7 @@ static const QString StateProperty("State");
 static const QString OfflineModeProperty("OfflineMode");
 static const QString DefaultServiceProperty("DefaultService");
 static const QString TetheringClientsProperty("TetheringClients");
+static const QString WiFiWpa3SupportProperty("WiFiWPA3Support");
 
 // ==========================================================================
 // NetworkManagerFactory
@@ -1511,6 +1512,24 @@ void NetworkManager::propertyChanged(const QString &name, const QVariant &value)
 
             updateDefaultRoute();
         }
+    } else if (name == WiFiWpa3SupportProperty) {
+        enum WifiWpa3Support wpa3Support = NetworkManager::Wpa3SupportFull;
+
+        if (m_priv->m_propertiesCache.value(name) == value)
+            return;
+
+        if (value == "full")
+            wpa3Support = NetworkManager::Wpa3SupportFull;
+        else if (value == "mixed")
+            wpa3Support = NetworkManager::Wpa3SupportMixed;
+        else if (value == "none")
+            wpa3Support = NetworkManager::Wpa3SupportNone;
+        else
+            qCDebug(lcConnman) << "Invalid WPA3 Support str" << value;
+
+         m_priv->m_propertiesCache[name] = (uint)wpa3Support;
+
+        Q_EMIT wifiWpa3SupportChanged();
     } else {
         if (m_priv->m_propertiesCache.value(name) == value)
             return;
@@ -1540,6 +1559,11 @@ uint NetworkManager::inputRequestTimeout() const
     bool ok = false;
     uint value = m_priv->m_propertiesCache.value(InputRequestTimeoutProperty).toUInt(&ok);
     return (ok && value) ? value : DefaultInputRequestTimeout;
+}
+
+NetworkManager::WifiWpa3Support NetworkManager::wifiWpa3Support() const
+{
+    return (NetworkManager::WifiWpa3Support)m_priv->m_propertiesCache.value(WiFiWpa3SupportProperty).toUInt();
 }
 
 bool NetworkManager::servicesEnabled() const

--- a/libconnman-qt/networkmanager.h
+++ b/libconnman-qt/networkmanager.h
@@ -34,6 +34,7 @@ class NetworkManager : public QObject
 {
     Q_OBJECT
     Q_ENUMS(State)
+    Q_ENUMS(WifiWpa3Support)
     Q_PROPERTY(bool available READ isAvailable NOTIFY availabilityChanged)
     // deprecated
     Q_PROPERTY(QString state READ state NOTIFY stateChanged)
@@ -45,6 +46,7 @@ class NetworkManager : public QObject
 
     Q_PROPERTY(bool sessionMode READ sessionMode WRITE setSessionMode NOTIFY sessionModeChanged)
     Q_PROPERTY(uint inputRequestTimeout READ inputRequestTimeout NOTIFY inputRequestTimeoutChanged)
+    Q_PROPERTY(WifiWpa3Support wifiWpa3Support READ wifiWpa3Support NOTIFY wifiWpa3SupportChanged)
 
     Q_PROPERTY(bool servicesEnabled READ servicesEnabled WRITE setServicesEnabled NOTIFY servicesEnabledChanged)
     Q_PROPERTY(bool technologiesEnabled READ technologiesEnabled WRITE setTechnologiesEnabled NOTIFY technologiesEnabledChanged)
@@ -68,6 +70,12 @@ public:
         IdleState,
         ReadyState,
         OnlineState
+    };
+
+    enum WifiWpa3Support {
+        Wpa3SupportFull,
+        Wpa3SupportMixed,
+        Wpa3SupportNone
     };
 
     static const QString WifiTechnologyPath;
@@ -114,6 +122,7 @@ public:
     // deprecated
     bool sessionMode() const;
     uint inputRequestTimeout() const;
+    WifiWpa3Support wifiWpa3Support() const;
 
     // deprecated
     bool servicesEnabled() const;
@@ -168,6 +177,7 @@ Q_SIGNALS:
     void globalStateChanged(State state);
     void offlineModeChanged(bool offlineMode);
     void inputRequestTimeoutChanged();
+    void wifiWpa3SupportChanged();
     void technologiesChanged();
     void servicesChanged();
     void savedServicesChanged();

--- a/plugin/declarativenetworkmanager.cpp
+++ b/plugin/declarativenetworkmanager.cpp
@@ -40,6 +40,8 @@ DeclarativeNetworkManager::DeclarativeNetworkManager(QObject *parent)
             this, &DeclarativeNetworkManager::offlineModeChanged);
     connect(m_sharedInstance.data(), &NetworkManager::inputRequestTimeoutChanged,
             this, &DeclarativeNetworkManager::inputRequestTimeoutChanged);
+    connect(m_sharedInstance.data(), &NetworkManager::wifiWpa3SupportChanged,
+            this, &DeclarativeNetworkManager::wifiWpa3SupportChanged);
     connect(m_sharedInstance.data(), &NetworkManager::defaultRouteChanged,
             this, &DeclarativeNetworkManager::defaultRouteChanged);
     connect(m_sharedInstance.data(), &NetworkManager::connectedWifiChanged,
@@ -144,6 +146,11 @@ bool DeclarativeNetworkManager::sessionMode() const
 uint DeclarativeNetworkManager::inputRequestTimeout() const
 {
     return m_sharedInstance->inputRequestTimeout();
+}
+
+DeclarativeNetworkManager::WifiWpa3Support DeclarativeNetworkManager::wifiWpa3Support() const
+{
+    return (DeclarativeNetworkManager::WifiWpa3Support)m_sharedInstance->wifiWpa3Support();
 }
 
 bool DeclarativeNetworkManager::servicesEnabled() const

--- a/plugin/declarativenetworkmanager.h
+++ b/plugin/declarativenetworkmanager.h
@@ -31,6 +31,7 @@ class DeclarativeNetworkManager: public QObject
 {
     Q_OBJECT
     Q_ENUMS(State)
+    Q_ENUMS(WifiWpa3Support)
     Q_PROPERTY(bool available READ isAvailable NOTIFY availabilityChanged)
     // deprecated
     Q_PROPERTY(QString state READ state NOTIFY stateChanged)
@@ -43,6 +44,7 @@ class DeclarativeNetworkManager: public QObject
 
     Q_PROPERTY(bool sessionMode READ sessionMode WRITE setSessionModeProperty NOTIFY sessionModeChanged)
     Q_PROPERTY(uint inputRequestTimeout READ inputRequestTimeout NOTIFY inputRequestTimeoutChanged)
+    Q_PROPERTY(WifiWpa3Support wifiWpa3Support READ wifiWpa3Support NOTIFY wifiWpa3SupportChanged)
 
     Q_PROPERTY(bool servicesEnabled READ servicesEnabled WRITE setServicesEnabled NOTIFY servicesEnabledChanged)
     Q_PROPERTY(bool technologiesEnabled READ technologiesEnabled WRITE setTechnologiesEnabled NOTIFY technologiesEnabledChanged)
@@ -69,6 +71,12 @@ public:
         OnlineState = NetworkManager::OnlineState
     };
 
+    enum WifiWpa3Support {
+        Wpa3SupportFull = NetworkManager::Wpa3SupportFull,
+        Wpa3SupportMixed = NetworkManager::Wpa3SupportMixed,
+        Wpa3SupportNone = NetworkManager::Wpa3SupportNone
+    };
+
     DeclarativeNetworkManager(QObject *parent = 0);
     virtual ~DeclarativeNetworkManager();
 
@@ -83,6 +91,7 @@ public:
 
     bool sessionMode() const;
     uint inputRequestTimeout() const;
+    WifiWpa3Support wifiWpa3Support() const;
 
     bool servicesEnabled() const;
     void setServicesEnabled(bool enabled);
@@ -144,6 +153,7 @@ Q_SIGNALS:
     void globalStateChanged();
     void offlineModeChanged();
     void inputRequestTimeoutChanged();
+    void wifiWpa3SupportChanged();
     void defaultRouteChanged();
     void connectedWifiChanged();
     void connectedEthernetChanged();

--- a/plugin/plugins.qmltypes
+++ b/plugin/plugins.qmltypes
@@ -125,6 +125,13 @@ Module {
                 "OnlineState": 4
             }
         }
+        Enum {
+            name: "WifiWpa3Support"
+            values: {
+                "Wpa3SupportFull": 0,
+                "Wpa3SupportMixed": 1,
+                "Wpa3SupportNone": 2
+        }
         Property { name: "available"; type: "bool"; isReadonly: true }
         Property { name: "state"; type: "string"; isReadonly: true }
         Property { name: "globalState"; type: "int"; isReadonly: true }


### PR DESCRIPTION
The property is added to ConnMan to indicate the level of WPA3 support on the WiFi adapter. This value is then propagated for UI to show/hide certain elements. The values are: "full", "mixed" and "none";