### PR TITLE
Add supported boolean property

### DIFF
--- a/libconnman-qt/networkservice.cpp
+++ b/libconnman-qt/networkservice.cpp
@@ -84,7 +84,8 @@ static QString ConnmanErrorInProgress = QStringLiteral("net.connman.Error.InProg
     ConnmanArg("mDNS", MDNS, mDNS) \
     ConnmanArg("mDNS.Configuration", MDNSConfiguration, mDNSConfiguration) \
     ConnmanArg("WPA3SAECheckMFP", WPA3SAECheckMFP, wpa3SaeCheckMfp) \
-    ConnmanArg("WPA3SAEPWE", WPA3SAEPWE, wpa3SaePwe)
+    ConnmanArg("WPA3SAEPWE", WPA3SAEPWE, wpa3SaePwe) \
+    ConnmanArg("Supported",Supported,supported)
 
 #define NETWORK_SERVICE_PROPERTIES2(Connman,Class) \
     NETWORK_SERVICE_PROPERTIES(Connman,Connman,Class,Class)
@@ -1154,6 +1155,9 @@ void NetworkService::Private::resetProperties()
             queueSignal(SignalWPA3SAECheckMFPChanged);
         } else if (key == WPA3SAEPWE) {
             queueSignal(SignalWPA3SAEPWEChanged);
+        } else if (key == Supported) {
+            if (value.toBool())
+                queueSignal(SignalSupportedChanged);
         }
     }
     updateManaged();
@@ -1281,6 +1285,8 @@ void NetworkService::Private::updatePropertyCache(const QString &name, const QVa
         queueSignal(SignalWPA3SAECheckMFPChanged);
     } else if (name == WPA3SAEPWE) {
         queueSignal(SignalWPA3SAEPWEChanged);
+    } else if (name == Supported) {
+        queueSignal(SignalSupportedChanged);
     }
 
     updateManaged();
@@ -1900,6 +1906,11 @@ bool NetworkService::wpa3SaeCheckMfp() const
 void NetworkService::setWpa3SaeCheckMfp(bool wpa3SaeCheckMfp)
 {
     m_priv->setProperty(Private::WPA3SAECheckMFP, wpa3SaeCheckMfp);
+}
+
+bool NetworkService::supported() const
+{
+    return m_priv->boolValue(Private::Supported);
 }
 
 QString NetworkService::wpa3SaePwe() const

--- a/libconnman-qt/networkservice.cpp
+++ b/libconnman-qt/networkservice.cpp
@@ -81,10 +81,10 @@ static QString ConnmanErrorInProgress = QStringLiteral("net.connman.Error.InProg
     ConnmanNoArg("Available",Available,available) \
     ConnmanNoArg("Saved",Saved,saved) \
     ClassNoArg(Valid,valid) \
-    ConnmanArg("mDNS", MDNS, mDNS) \
-    ConnmanArg("mDNS.Configuration", MDNSConfiguration, mDNSConfiguration) \
-    ConnmanArg("WPA3SAECheckMFP", WPA3SAECheckMFP, wpa3SaeCheckMfp) \
-    ConnmanArg("WPA3SAEPWE", WPA3SAEPWE, wpa3SaePwe) \
+    ConnmanArg("mDNS",MDNS,mDNS) \
+    ConnmanArg("mDNS.Configuration",MDNSConfiguration,mDNSConfiguration) \
+    ConnmanArg("WPA3SAECheckMFP",WPA3SAECheckMFP,wpa3SaeCheckMfp) \
+    ConnmanArg("WPA3SAEPWE",WPA3SAEPWE,wpa3SaePwe) \
     ConnmanArg("Supported",Supported,supported)
 
 #define NETWORK_SERVICE_PROPERTIES2(Connman,Class) \

--- a/libconnman-qt/networkservice.h
+++ b/libconnman-qt/networkservice.h
@@ -89,6 +89,7 @@ class NetworkService : public QObject
     Q_PROPERTY(bool mDNSConfiguration READ mDNSConfiguration WRITE setmDNSConfiguration NOTIFY mDNSConfigurationChanged)
     Q_PROPERTY(bool wpa3SaeCheckMfp READ wpa3SaeCheckMfp WRITE setWpa3SaeCheckMfp NOTIFY wpa3SaeCheckMfpChanged)
     Q_PROPERTY(QString wpa3SaePwe READ wpa3SaePwe WRITE setWpa3SaePwe NOTIFY wpa3SaePweChanged)
+    Q_PROPERTY(bool supported READ supported NOTIFY supportedChanged)
 
     class Private;
     friend class Private;
@@ -164,6 +165,7 @@ public:
     void setWpa3SaeCheckMfp(bool wpa3SaeCheckMfp);
     QString wpa3SaePwe() const;
     void setWpa3SaePwe(const QString &wpa3SaePwe);
+    bool supported() const;
 
     void setPath(const QString &path);
     void updateProperties(const QVariantMap &properties);
@@ -262,6 +264,7 @@ Q_SIGNALS:
     void mDNSConfigurationChanged(bool mDNSConfiguration);
     void wpa3SaeCheckMfpChanged(bool wpa3SaeCheckMfp);
     void wpa3SaePweChanged(const QString &wpa3SaePwe);
+    void supportedChanged(bool supported);
 
     void serviceConnectionStarted();
     void serviceDisconnectionStarted();

--- a/plugin/plugins.qmltypes
+++ b/plugin/plugins.qmltypes
@@ -424,6 +424,7 @@ Module {
         Property { name: "mDNSConfiguration"; type: "bool" }
         Property { name: "wpa3SaeCheckMfp"; type: "bool" }
         Property { name: "wpa3SaePwe"; type: "string" }
+        Property { name: "supported"; type: "bool"; isReadonly: true }
         Signal {
             name: "nameChanged"
             Parameter { name: "name"; type: "string" }
@@ -579,6 +580,9 @@ Module {
         Signal {
             name: "wpa3SaePweChanged"
             Parameter { name: "wpa3SaePwe"; type: "string" }
+        Signal {
+            name: "supportedChanged"
+            Parameter { name: "supported"; type: "bool" }
         }
         Signal { name: "serviceConnectionStarted" }
         Signal { name: "serviceDisconnectionStarted" }

--- a/plugin/savedservicemodel.cpp
+++ b/plugin/savedservicemodel.cpp
@@ -16,6 +16,12 @@ namespace
 
 bool compareServices(NetworkService *a, NetworkService *b)
 {
+    if (a->supported() && !b->supported())
+            return true;
+
+    if (b->supported() && !a->supported())
+            return false;
+
     if (a->available() && !b->available())
         return true;
 

--- a/rpm/connman-qt5.spec
+++ b/rpm/connman-qt5.spec
@@ -1,11 +1,11 @@
 Name:       connman-qt5
 Summary:    Qt bindings for connman
-Version:    1.4.18
+Version:    1.4.22
 Release:    1
 License:    ASL 2.0
 URL:        https://github.com/sailfishos/libconnman-qt/
 Source0:    %{name}-%{version}.tar.bz2
-Requires:   connman >= 1.40+git9
+Requires:   connman >= 1.40+git14
 Requires:   libdbusaccess >= 1.0.4
 Requires(post): /sbin/ldconfig
 Requires(postun): /sbin/ldconfig


### PR DESCRIPTION
This property tells if the network is supported or not based on the device WPA3 support level and the network security. If the device does not have full WPA3 support this is `false` for all WPA3 SAE networks.

Requires https://github.com/sailfishos/connman/pull/132