### PR TITLE
[libconnman-qt] Avoid declaring invokable setters for new properties.  JB#64190

### DIFF
--- a/libconnman-qt/networkservice.h
+++ b/libconnman-qt/networkservice.h
@@ -159,8 +159,11 @@ public:
     QString anonymousIdentity() const;
     bool mDNS() const;
     bool mDNSConfiguration() const;
+    void setmDNSConfiguration(bool mDNSConfiguration);
     bool wpa3SaeCheckMfp() const;
+    void setWpa3SaeCheckMfp(bool wpa3SaeCheckMfp);
     QString wpa3SaePwe() const;
+    void setWpa3SaePwe(const QString &wpa3SaePwe);
 
     void setPath(const QString &path);
     void updateProperties(const QVariantMap &properties);
@@ -312,9 +315,6 @@ public Q_SLOTS:
     void setDomainSuffixMatch(const QString &domainSuffixMatch);
     void setPhase2(const QString &phase2);
     void setAnonymousIdentity(const QString &anonymousIdentity);
-    void setmDNSConfiguration(bool mDNSConfiguration);
-    void setWpa3SaeCheckMfp(bool wpa3SaeCheckMfp);
-    void setWpa3SaePwe(const QString &wpa3SaePwe);
 
     void resetCounters();
 

--- a/plugin/plugins.qmltypes
+++ b/plugin/plugins.qmltypes
@@ -131,6 +131,7 @@ Module {
                 "Wpa3SupportFull": 0,
                 "Wpa3SupportMixed": 1,
                 "Wpa3SupportNone": 2
+            }
         }
         Property { name: "available"; type: "bool"; isReadonly: true }
         Property { name: "state"; type: "string"; isReadonly: true }
@@ -142,6 +143,7 @@ Module {
         Property { name: "connectingWifi"; type: "bool"; isReadonly: true }
         Property { name: "sessionMode"; type: "bool" }
         Property { name: "inputRequestTimeout"; type: "uint"; isReadonly: true }
+        Property { name: "wifiWpa3Support"; type: "WifiWpa3Support"; isReadonly: true }
         Property { name: "servicesEnabled"; type: "bool" }
         Property { name: "technologiesEnabled"; type: "bool" }
         Property { name: "valid"; type: "bool"; isReadonly: true }
@@ -420,6 +422,8 @@ Module {
         Property { name: "anonymousIdentity"; type: "string" }
         Property { name: "mDNS"; type: "bool"; isReadonly: true }
         Property { name: "mDNSConfiguration"; type: "bool" }
+        Property { name: "wpa3SaeCheckMfp"; type: "bool" }
+        Property { name: "wpa3SaePwe"; type: "string" }
         Signal {
             name: "nameChanged"
             Parameter { name: "name"; type: "string" }
@@ -568,6 +572,14 @@ Module {
             name: "mDNSConfigurationChanged"
             Parameter { name: "mDNSConfiguration"; type: "bool" }
         }
+        Signal {
+            name: "wpa3SaeCheckMfpChanged"
+            Parameter { name: "wpa3SaeCheckMfp"; type: "bool" }
+        }
+        Signal {
+            name: "wpa3SaePweChanged"
+            Parameter { name: "wpa3SaePwe"; type: "string" }
+        }
         Signal { name: "serviceConnectionStarted" }
         Signal { name: "serviceDisconnectionStarted" }
         Signal {
@@ -673,10 +685,6 @@ Module {
         Method {
             name: "setAnonymousIdentity"
             Parameter { name: "anonymousIdentity"; type: "string" }
-        }
-        Method {
-            name: "setmDNSConfiguration"
-            Parameter { name: "mDNSConfiguration"; type: "bool" }
         }
         Method { name: "resetCounters" }
     }


### PR DESCRIPTION
Qml side should be using just the property. There shouldn't be anything needing a real invokable method here. As new api we should be still ok adjusting these.

Also regenerated the qmltypes and noticed some other shortcomings there as well.